### PR TITLE
feat(vsr): implement LipCoordNet architecture with dual inputs

### DIFF
--- a/app/src/main/java/com/hereliesaz/liperty/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/MainActivity.kt
@@ -129,7 +129,7 @@ class MainActivity : ComponentActivity() {
         // VoiceConverter is initialized lazily or in onCreate
         // For simplicity, let's use the one in LaryngealSensor if EL mode is active.
         // But MainActivity might need its own if it does other things.
-        frameBuffer = FrameBuffer(capacity = 50) // VSR model input: [1, 50, 88, 88, 1]
+        frameBuffer = FrameBuffer(capacity = 50) // VSR model input: [1, 50, 96, 96, 1]
         cameraExecutor = Executors.newSingleThreadExecutor()
 
         // Initialize TFLite in background
@@ -490,12 +490,13 @@ class MainActivity : ComponentActivity() {
                  FaceLandmarkerHelper.calculateHeadPose(matrix)
             }
 
-            // Crop & Align — crop to 88×88 to match the model's native input size directly,
+            // Crop & Align — crop to 128x64 to match the model's native input size directly,
             // avoiding a second redundant scale step inside VSRInference.
             val rotation = FaceLandmarkerHelper.calculateLipRotation(result)
-            val cropSize = 88
-            val reusableBitmap = BitmapPool.get(cropSize, cropSize)
-            val alignedMouth = ImageUtils.alignAndCropMouth(bitmap, lipBox, rotation, cropSize, reusableBitmap)
+            val cropWidth = 128
+            val cropHeight = 64
+            val reusableBitmap = BitmapPool.get(cropWidth, cropHeight)
+            val alignedMouth = ImageUtils.alignAndCropMouth(bitmap, lipBox, rotation, cropWidth, cropHeight, reusableBitmap)
 
             // Normalization bypassed: applyNormalizationNative (JNI) was modifying frames
             // in-place in a way that may make all frames identical (histogram equalization
@@ -504,8 +505,8 @@ class MainActivity : ComponentActivity() {
 
             // Diagnostic: log mean pixel brightness of first frame in each batch to confirm input varies
             if (frameBuffer.size() == 0) {
-                val pixels = IntArray(cropSize * cropSize)
-                processedMouth.getPixels(pixels, 0, cropSize, 0, 0, cropSize, cropSize)
+                val pixels = IntArray(cropWidth * cropHeight)
+                processedMouth.getPixels(pixels, 0, cropWidth, 0, 0, cropWidth, cropHeight)
                 val mean = pixels.map { android.graphics.Color.red(it) }.average()
                 Log.d("VSRInput", "frame0 mean_brightness=%.1f lipBox=$rawLipBox".format(mean))
             }
@@ -519,17 +520,31 @@ class MainActivity : ComponentActivity() {
             // DO NOT RECYCLE reusableBitmap HERE. It is now owned by frameBuffer via processedMouth reference!
 
             // Add to Buffer
-            frameBuffer.addFrame(processedMouth)
+            // Extract landmarks for LipCoordNet input: 40 coordinates (20 inner lip points x 2)
+            val landmarkArray = FloatArray(40)
+            rawLandmarks?.let { lms ->
+                // MediaPipe Face Mesh lip indices (inner lip specifically, approx 20 points)
+                val innerLipIndices = intArrayOf(78, 191, 80, 81, 82, 13, 312, 311, 310, 415, 308, 324, 318, 402, 317, 14, 87, 178, 88, 95)
+                for (i in innerLipIndices.indices) {
+                    if (innerLipIndices[i] < lms.size) {
+                        landmarkArray[i * 2] = lms[innerLipIndices[i]].x()
+                        landmarkArray[i * 2 + 1] = lms[innerLipIndices[i]].y()
+                    }
+                }
+            }
+            frameBuffer.addFrame(processedMouth, landmarkArray)
 
             // Inference
             if (frameBuffer.isFull() && !isInferencing) {
                 isInferencing = true
                 Log.d("VSRPipeline", "buffer full — launching inference")
                 // Takes ownership of the frames
-                val framesToProcess = frameBuffer.clearAndGetFrames()
+                val bufferEntries = frameBuffer.clearAndGetFrames()
+                val framesToProcess = bufferEntries.map { it.first }
+                val landmarksToProcess = bufferEntries.flatMap { it.second?.toList() ?: List(40) { 0f } }.toFloatArray()
 
                 lifecycleScope.launch(Dispatchers.Default) {
-                    val vsrResult = vsrInference.runInference(framesToProcess)
+                    val vsrResult = vsrInference.runInference(framesToProcess, landmarksToProcess)
                     // Once inference is complete, explicitly recycle the frames
                     for (frame in framesToProcess) {
                         BitmapPool.recycle(frame)

--- a/app/src/main/java/com/hereliesaz/liperty/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/MainActivity.kt
@@ -129,7 +129,7 @@ class MainActivity : ComponentActivity() {
         // VoiceConverter is initialized lazily or in onCreate
         // For simplicity, let's use the one in LaryngealSensor if EL mode is active.
         // But MainActivity might need its own if it does other things.
-        frameBuffer = FrameBuffer(capacity = 50) // VSR model input: [1, 50, 96, 96, 1]
+        frameBuffer = FrameBuffer(capacity = 50) // VSR model input: [1, 50, 64, 128, 1]
         cameraExecutor = Executors.newSingleThreadExecutor()
 
         // Initialize TFLite in background

--- a/app/src/main/java/com/hereliesaz/liperty/ml/FrameBuffer.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/ml/FrameBuffer.kt
@@ -5,24 +5,24 @@ import java.util.ArrayDeque
 
 class FrameBuffer(private val capacity: Int) {
 
-    private val buffer = ArrayDeque<Bitmap>(capacity)
+    private val buffer = ArrayDeque<Pair<Bitmap, FloatArray?>>(capacity)
 
     /**
-     * Adds a frame to the buffer.
+     * Adds a frame and an optional array of landmarks to the buffer.
      * If the buffer is full, the oldest frame is removed and recycled securely via BitmapPool.
      * Thread-safe.
      */
     @Synchronized
-    fun addFrame(bitmap: Bitmap) {
+    fun addFrame(bitmap: Bitmap, landmarks: FloatArray? = null) {
         if (buffer.size >= capacity) {
-            val oldBitmap = buffer.removeFirst()
-            com.hereliesaz.liperty.utils.BitmapPool.recycle(oldBitmap)
+            val oldEntry = buffer.removeFirst()
+            com.hereliesaz.liperty.utils.BitmapPool.recycle(oldEntry.first)
         }
-        buffer.addLast(bitmap)
+        buffer.addLast(Pair(bitmap, landmarks))
     }
 
     @Synchronized
-    fun getFrames(): List<Bitmap> {
+    fun getFrames(): List<Pair<Bitmap, FloatArray?>> {
         return buffer.toList()
     }
 
@@ -31,7 +31,7 @@ class FrameBuffer(private val capacity: Int) {
      * The caller is now responsible for recycling the returned Bitmaps.
      */
     @Synchronized
-    fun clearAndGetFrames(): List<Bitmap> {
+    fun clearAndGetFrames(): List<Pair<Bitmap, FloatArray?>> {
         val frames = buffer.toList()
         buffer.clear()
         return frames // Caller assumes ownership for recycling
@@ -50,8 +50,8 @@ class FrameBuffer(private val capacity: Int) {
      */
     @Synchronized
     fun clearAndRecycle() {
-        for (bitmap in buffer) {
-            com.hereliesaz.liperty.utils.BitmapPool.recycle(bitmap)
+        for (entry in buffer) {
+            com.hereliesaz.liperty.utils.BitmapPool.recycle(entry.first)
         }
         buffer.clear()
     }

--- a/app/src/main/java/com/hereliesaz/liperty/ml/LanguageModel.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/ml/LanguageModel.kt
@@ -68,4 +68,13 @@ class LanguageModel {
         val nextMap = bigramMap[prevToken] ?: return UNIFORM_PROB
         return nextMap[currentToken] ?: UNIFORM_PROB
     }
+
+    /**
+     * Returns P(currentWord | prevWord).
+     * Used for disambiguating homophenes based on preceding word context.
+     */
+    fun getWordScore(prevWord: String, currentWord: String): Double {
+        val nextMap = WordBigramProvider.map[prevWord.lowercase()] ?: return UNIFORM_PROB
+        return nextMap[currentWord.lowercase()] ?: UNIFORM_PROB
+    }
 }

--- a/app/src/main/java/com/hereliesaz/liperty/ml/ModelEngine.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/ml/ModelEngine.kt
@@ -5,6 +5,15 @@ import java.nio.ByteBuffer
 interface ModelEngine {
     fun initialize(): Boolean
     fun run(inputBuffer: ByteBuffer, outputBuffer: ByteBuffer)
+    // Optional: Overload for multi-input models (e.g., dual-input LipCoordNet)
+    fun run(inputBuffers: Array<Any>, outputBuffer: ByteBuffer) {
+        // By default, fallback to single input if array has 1 element
+        if (inputBuffers.size == 1 && inputBuffers[0] is ByteBuffer) {
+            run(inputBuffers[0] as ByteBuffer, outputBuffer)
+        } else {
+            throw UnsupportedOperationException("Multi-input run() not implemented for this engine.")
+        }
+    }
     fun getOutputShape(outputIndex: Int): IntArray
     fun getInputShape(inputIndex: Int): IntArray
     fun close()

--- a/app/src/main/java/com/hereliesaz/liperty/ml/TFLiteEngine.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/ml/TFLiteEngine.kt
@@ -72,13 +72,23 @@ class TFLiteEngine(
         interp.run(inputBuffer, outputBuffer)
     }
 
+    override fun run(inputBuffers: Array<Any>, outputBuffer: ByteBuffer) {
+        val interp = interpreter
+        if (interp == null) {
+            Log.e("TFLiteEngine", "run() called but '$modelName' is not loaded — skipped")
+            return
+        }
+        val outputs = mapOf(0 to outputBuffer)
+        interp.runForMultipleInputsOutputs(inputBuffers, outputs)
+    }
+
     override fun getOutputShape(outputIndex: Int): IntArray =
         interpreter?.getOutputTensor(outputIndex)?.shape()
             ?: intArrayOf(1, 50, 40)
 
     override fun getInputShape(inputIndex: Int): IntArray =
         interpreter?.getInputTensor(inputIndex)?.shape()
-            ?: intArrayOf(1, 50, 88, 88, 1)
+            ?: if (inputIndex == 0) intArrayOf(1, 50, 64, 128, 1) else intArrayOf(1, 50, 40) // Dummy landmark array shape
 
     override fun close() {
         interpreter?.close()

--- a/app/src/main/java/com/hereliesaz/liperty/ml/VSRInference.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/ml/VSRInference.kt
@@ -22,8 +22,8 @@ class VSRInference(private val engine: ModelEngine) {
     private var useBeamSearch = true
 
     // Default Constants (overridden dynamically by model shape)
-    private var inputWidth = 88
-    private var inputHeight = 88
+    private var inputWidth = 128
+    private var inputHeight = 64
     private var numFrames = 50
     private var numChannels = 1
 
@@ -36,9 +36,9 @@ class VSRInference(private val engine: ModelEngine) {
     }
 
     /**
-     * Runs inference on the provided frames.
+     * Runs inference on the provided frames and (optionally) lip landmarks.
      */
-    fun runInference(frames: List<Bitmap>): VSRResult {
+    fun runInference(frames: List<Bitmap>, landmarks: FloatArray? = null): VSRResult {
         val startTime = SystemClock.uptimeMillis()
 
         try {
@@ -131,7 +131,26 @@ class VSRInference(private val engine: ModelEngine) {
             outputBuffer.order(ByteOrder.nativeOrder())
 
             // 3. Run Inference
-            engine.run(inputBuffer, outputBuffer)
+            if (landmarks != null) {
+                // Secondary input buffer for LipCoordNet landmarks
+                val landmarkShape = engine.getInputShape(1)
+                val landmarkElements = if (landmarkShape.isNotEmpty()) landmarkShape.reduce { acc, i -> acc * i } else landmarks.size
+                val landmarkBuffer = ByteBuffer.allocateDirect(landmarkElements * 4).order(ByteOrder.nativeOrder())
+
+                // Copy landmarks or pad/truncate to match expected shape
+                for (i in 0 until landmarkElements) {
+                    if (i < landmarks.size) {
+                        landmarkBuffer.putFloat(landmarks[i])
+                    } else {
+                        landmarkBuffer.putFloat(0f)
+                    }
+                }
+                landmarkBuffer.rewind()
+
+                engine.run(arrayOf(inputBuffer, landmarkBuffer), outputBuffer)
+            } else {
+                engine.run(inputBuffer, outputBuffer)
+            }
 
             outputBuffer.rewind()
 

--- a/app/src/main/java/com/hereliesaz/liperty/ml/WordBigramProvider.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/ml/WordBigramProvider.kt
@@ -1,0 +1,33 @@
+package com.hereliesaz.liperty.ml
+
+object WordBigramProvider {
+    val map: Map<String, Map<String, Double>> = mapOf(
+        "i" to mapOf("am" to 0.2, "will" to 0.1, "can" to 0.1, "have" to 0.1, "do" to 0.05, "don't" to 0.05, "was" to 0.05),
+        "you" to mapOf("are" to 0.2, "will" to 0.1, "can" to 0.1, "have" to 0.1, "do" to 0.05, "don't" to 0.05, "were" to 0.05),
+        "he" to mapOf("is" to 0.2, "will" to 0.1, "has" to 0.1, "was" to 0.05, "doesn't" to 0.05),
+        "she" to mapOf("is" to 0.2, "will" to 0.1, "has" to 0.1, "was" to 0.05, "doesn't" to 0.05),
+        "we" to mapOf("are" to 0.2, "will" to 0.1, "have" to 0.1, "can" to 0.1, "were" to 0.05),
+        "they" to mapOf("are" to 0.2, "will" to 0.1, "have" to 0.1, "can" to 0.1, "were" to 0.05),
+        "it" to mapOf("is" to 0.2, "was" to 0.1, "will" to 0.1, "has" to 0.1, "doesn't" to 0.05),
+
+        "am" to mapOf("i" to 0.1, "going" to 0.1, "a" to 0.1, "the" to 0.05),
+        "is" to mapOf("a" to 0.1, "the" to 0.1, "it" to 0.1, "not" to 0.1, "going" to 0.05),
+        "are" to mapOf("you" to 0.1, "we" to 0.1, "they" to 0.1, "a" to 0.05, "the" to 0.05, "going" to 0.05),
+
+        "to" to mapOf("be" to 0.1, "do" to 0.1, "go" to 0.1, "the" to 0.1, "a" to 0.05, "have" to 0.05),
+        "the" to mapOf("same" to 0.05, "time" to 0.05, "first" to 0.05, "way" to 0.05, "end" to 0.05),
+        "a" to mapOf("lot" to 0.05, "little" to 0.05, "good" to 0.05, "great" to 0.05, "new" to 0.05),
+
+        "in" to mapOf("the" to 0.2, "a" to 0.1, "this" to 0.05, "that" to 0.05),
+        "on" to mapOf("the" to 0.2, "a" to 0.1, "my" to 0.05, "this" to 0.05),
+        "at" to mapOf("the" to 0.2, "a" to 0.1, "this" to 0.05, "that" to 0.05),
+        "of" to mapOf("the" to 0.2, "a" to 0.1, "my" to 0.05, "this" to 0.05),
+
+        "can" to mapOf("you" to 0.1, "we" to 0.1, "i" to 0.1, "be" to 0.1, "do" to 0.1),
+        "will" to mapOf("be" to 0.2, "have" to 0.1, "you" to 0.1, "we" to 0.1, "i" to 0.1),
+        "have" to mapOf("a" to 0.1, "the" to 0.1, "been" to 0.1, "to" to 0.1),
+
+        "this" to mapOf("is" to 0.2, "was" to 0.1, "one" to 0.1, "time" to 0.05),
+        "that" to mapOf("is" to 0.1, "was" to 0.1, "we" to 0.1, "you" to 0.1, "i" to 0.1)
+    )
+}

--- a/app/src/main/java/com/hereliesaz/liperty/ui/TranscriptionManager.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/ui/TranscriptionManager.kt
@@ -2,10 +2,16 @@ package com.hereliesaz.liperty.ui
 
 import android.content.Context
 import com.hereliesaz.liperty.ml.HomopheneCorrector
+import com.hereliesaz.liperty.ml.LanguageModel
 
 class TranscriptionManager(private val context: Context) {
 
+    companion object {
+        private val WHITESPACE_REGEX = "\\s+".toRegex()
+    }
+
     private val homopheneCorrector = HomopheneCorrector(context)
+    private val languageModel = LanguageModel()
 
     // Each entry is (word, confidence) — confidence comes from the VSR model's softmax output.
     private val wordEntries = mutableListOf<Pair<String, Float>>()
@@ -13,13 +19,54 @@ class TranscriptionManager(private val context: Context) {
 
     /**
      * Appends new words from an inference result.
+     * Uses a language model to automatically correct common homophenes based on context.
      * @param confidence Mean max-softmax probability for this inference window (0–1).
      */
     fun appendText(text: String, confidence: Float = 0f) {
         if (text.isEmpty()) return
-        val newWords = text.trim().split("\\s+".toRegex())
-        newWords.forEach { wordEntries.add(Pair(it, confidence)) }
+        val newWords = text.trim().split(WHITESPACE_REGEX)
+
+        for (word in newWords) {
+            var bestWord = word
+            val prevWord = wordEntries.lastOrNull()?.first
+
+            if (prevWord != null) {
+                val alternatives = buildAlternatives(word)
+
+                // Score them with the language model if there are alternatives
+                if (alternatives.size > 1) {
+                    var bestScore = -1.0
+                    for (alt in alternatives) {
+                        val score = languageModel.getWordScore(prevWord, alt)
+                        if (score > bestScore) {
+                            bestScore = score
+                            bestWord = alt
+                        }
+                    }
+                }
+            }
+
+            val formattedWord = applyOriginalCasing(word, bestWord)
+            wordEntries.add(Pair(formattedWord, confidence))
+        }
+
         if (wordEntries.isNotEmpty()) selectedWordIndex = wordEntries.size - 1
+    }
+
+    private fun buildAlternatives(word: String): List<String> {
+        val alternatives = homopheneCorrector.getAlternatives(word).toMutableList()
+        // Ensure the original word is at the front to act as the default for tie-breaking
+        alternatives.removeAll { it.equals(word, ignoreCase = true) }
+        alternatives.add(0, word)
+        return alternatives
+    }
+
+    private fun applyOriginalCasing(original: String, corrected: String): String {
+        return if (original.firstOrNull()?.isUpperCase() == true) {
+            corrected.replaceFirstChar { it.uppercase() }
+        } else {
+            corrected
+        }
     }
 
     fun getCurrentSentence(): String = wordEntries.joinToString(" ") { it.first }

--- a/app/src/main/java/com/hereliesaz/liperty/utils/ImageUtils.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/utils/ImageUtils.kt
@@ -149,30 +149,30 @@ object ImageUtils {
     /**
      * Aligns and crops the mouth region from the input bitmap.
      */
-    fun alignAndCropMouth(bitmap: Bitmap, mouthRect: Rect, rotationDegrees: Float, targetSize: Int): Bitmap {
-        val targetBitmap = Bitmap.createBitmap(targetSize, targetSize, Bitmap.Config.ARGB_8888)
-        return alignAndCropMouth(bitmap, mouthRect, rotationDegrees, targetSize, targetBitmap)
+    fun alignAndCropMouth(bitmap: Bitmap, mouthRect: Rect, rotationDegrees: Float, targetWidth: Int, targetHeight: Int): Bitmap {
+        val targetBitmap = Bitmap.createBitmap(targetWidth, targetHeight, Bitmap.Config.ARGB_8888)
+        return alignAndCropMouth(bitmap, mouthRect, rotationDegrees, targetWidth, targetHeight, targetBitmap)
     }
 
     /**
      * Overload that writes to a reused bitmap to reduce allocation.
      */
-    fun alignAndCropMouth(bitmap: Bitmap, mouthRect: Rect, rotationDegrees: Float, targetSize: Int, destBitmap: Bitmap): Bitmap {
+    fun alignAndCropMouth(bitmap: Bitmap, mouthRect: Rect, rotationDegrees: Float, targetWidth: Int, targetHeight: Int, destBitmap: Bitmap): Bitmap {
         // Ensure destBitmap is correct size, if not, recreate (though typically caller ensures this)
-        val targetBitmap = if (destBitmap.width != targetSize || destBitmap.height != targetSize) {
-            Bitmap.createBitmap(targetSize, targetSize, Bitmap.Config.ARGB_8888)
+        val targetBitmap = if (destBitmap.width != targetWidth || destBitmap.height != targetHeight) {
+            Bitmap.createBitmap(targetWidth, targetHeight, Bitmap.Config.ARGB_8888)
         } else {
             destBitmap
         }
 
         val canvas = Canvas(targetBitmap)
-        val scale = targetSize.toFloat() / max(mouthRect.width(), 1)
+        val scale = targetWidth.toFloat() / max(mouthRect.width(), 1) // Base scale on width primarily
 
         val drawingMatrix = android.graphics.Matrix()
         drawingMatrix.postTranslate(-mouthRect.centerX().toFloat(), -mouthRect.centerY().toFloat())
         drawingMatrix.postRotate(rotationDegrees)
         drawingMatrix.postScale(scale, scale)
-        drawingMatrix.postTranslate(targetSize / 2f, targetSize / 2f)
+        drawingMatrix.postTranslate(targetWidth / 2f, targetHeight / 2f)
 
         val paint = Paint()
         paint.isFilterBitmap = true

--- a/app/src/test/java/com/HereLiesAz/liperty/ml/VSRInferenceTest.kt
+++ b/app/src/test/java/com/HereLiesAz/liperty/ml/VSRInferenceTest.kt
@@ -54,7 +54,7 @@ class VSRInferenceTest {
         vsr.initialize()
         assert(engine.initialized)
 
-        val frames = List(5) { Bitmap.createBitmap(88, 88, Bitmap.Config.ARGB_8888) }
+        val frames = List(5) { Bitmap.createBitmap(96, 96, Bitmap.Config.ARGB_8888) }
         val result = vsr.runInference(frames)
 
         assert(engine.runCalled)
@@ -79,7 +79,7 @@ class VSRInferenceTest {
          }
 
          val vsr = VSRInference(engine)
-         val frames = listOf(Bitmap.createBitmap(88, 88, Bitmap.Config.ARGB_8888))
+         val frames = listOf(Bitmap.createBitmap(96, 96, Bitmap.Config.ARGB_8888))
          val result = vsr.runInference(frames)
 
          assertEquals("", result.text)

--- a/app/src/test/java/com/HereLiesAz/liperty/ml/VSRInferenceTest.kt
+++ b/app/src/test/java/com/HereLiesAz/liperty/ml/VSRInferenceTest.kt
@@ -54,7 +54,7 @@ class VSRInferenceTest {
         vsr.initialize()
         assert(engine.initialized)
 
-        val frames = List(5) { Bitmap.createBitmap(96, 96, Bitmap.Config.ARGB_8888) }
+        val frames = List(5) { Bitmap.createBitmap(128, 64, Bitmap.Config.ARGB_8888) }
         val result = vsr.runInference(frames)
 
         assert(engine.runCalled)

--- a/app/src/test/java/com/HereLiesAz/liperty/ml/VSRInferenceTest.kt
+++ b/app/src/test/java/com/HereLiesAz/liperty/ml/VSRInferenceTest.kt
@@ -79,7 +79,7 @@ class VSRInferenceTest {
          }
 
          val vsr = VSRInference(engine)
-         val frames = listOf(Bitmap.createBitmap(96, 96, Bitmap.Config.ARGB_8888))
+         val frames = listOf(Bitmap.createBitmap(128, 64, Bitmap.Config.ARGB_8888))
          val result = vsr.runInference(frames)
 
          assertEquals("", result.text)

--- a/app/src/test/java/com/HereLiesAz/liperty/utils/ImageUtilsTest.kt
+++ b/app/src/test/java/com/HereLiesAz/liperty/utils/ImageUtilsTest.kt
@@ -27,12 +27,13 @@ class ImageUtilsTest {
     fun testAlignAndCropMouth() {
         val bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888)
         val rect = Rect(40, 40, 60, 60)
-        val targetSize = 88
+        val targetWidth = 128
+        val targetHeight = 64
 
-        val aligned = ImageUtils.alignAndCropMouth(bitmap, rect, 0f, targetSize)
+        val aligned = ImageUtils.alignAndCropMouth(bitmap, rect, 0f, targetWidth, targetHeight)
 
-        assertEquals(targetSize, aligned.width)
-        assertEquals(targetSize, aligned.height)
+        assertEquals(targetWidth, aligned.width)
+        assertEquals(targetHeight, aligned.height)
     }
 
     @Test

--- a/tools/create_dummy_model.py
+++ b/tools/create_dummy_model.py
@@ -2,9 +2,9 @@ import tensorflow as tf
 import os
 
 def create_dummy_model():
-    # Define input shape: (Batch=1, Time=50, Height=88, Width=88, Channel=1)
-    # This shape is based on common VSR model inputs like LipNet/VALLR (as per RESEARCH.md)
-    input_layer = tf.keras.layers.Input(shape=(50, 88, 88, 1), batch_size=1, name="input_video")
+    # Define input shapes for LipCoordNet: (Batch=1, Time=50, Height=64, Width=128, Channel=1) and Landmarks
+    input_layer = tf.keras.layers.Input(shape=(50, 64, 128, 1), batch_size=1, name="input_video")
+    landmark_layer = tf.keras.layers.Input(shape=(50, 40), batch_size=1, name="input_landmarks")
 
     # Simple transformation to reach output shape (1, 50, 40)
     # 1. TimeDistributed Conv2D to process frames
@@ -15,6 +15,9 @@ def create_dummy_model():
 
     # Flatten spatial dimensions: (1, 50, H, W, C) -> (1, 50, Features)
     x = tf.keras.layers.TimeDistributed(tf.keras.layers.Flatten())(x)
+
+    # Concatenate visual features with landmark features
+    x = tf.keras.layers.Concatenate(axis=-1)([x, landmark_layer])
 
     # Recurrent layers to model temporal dependencies
     x = tf.keras.layers.Bidirectional(tf.keras.layers.LSTM(64, return_sequences=True))(x)
@@ -34,7 +37,7 @@ def create_dummy_model():
     # (Note: This is hard to do in a simple Keras functional API setup without a custom layer,
     # but we can try to adjust the bias of the dense layer after creation)
 
-    model = tf.keras.Model(inputs=input_layer, outputs=output_layer)
+    model = tf.keras.Model(inputs=[input_layer, landmark_layer], outputs=output_layer)
 
     # Manually adjust bias to favor blank (index 0) to prevent constant "VG" output
     weights = model.get_layer("ctc_output").get_weights()


### PR DESCRIPTION
* Refactored `ImageUtils` and `MainActivity` to crop lip ROI to 128x64.
* Updated `MainActivity` to extract 40 internal lip landmarks using `MediaPipe` Face Mesh.
* Updated `FrameBuffer` to store `Pair<Bitmap, FloatArray?>` to synchronize video frames and landmark data.
* Updated `TFLiteEngine`, `ModelEngine`, and `VSRInference` to support multi-input `.tflite` execution.
* Modified `tools/create_dummy_model.py` to generate a 128x64 dual-input Keras model and re-exported `vsr_model.tflite`.
* Fixed `TranscriptionManager` to compile regex once and properly prioritize the original word in homophene tie-breaks.

## Summary by Sourcery

Support dual-input LipCoordNet inference with synchronized landmark features and refine transcription post-processing.

New Features:
- Add support for dual-input VSR models by feeding both video frames and lip landmark features into the inference pipeline.
- Introduce a word-level bigram language model for context-aware homophene correction in transcriptions.

Bug Fixes:
- Adjust homophene tie-breaking to prioritize the original recognized word and compile the whitespace regex once for reuse in transcription handling.

Enhancements:
- Change lip-region cropping and model input dimensions to 128x64 to match the new VSR model expectations.
- Extend the frame buffer, model engine, and TFLite engine to handle paired frame/landmark entries and multi-input TFLite execution.
- Update image alignment utilities and associated tests to reflect the new non-square lip ROI.
- Revise the dummy Keras model generator to build and export a dual-input LipCoordNet-style TFLite model.

Tests:
- Update VSR inference and image utility tests to use the new input resolutions and interfaces.