### PR TITLE
Fix immediate force-close when ML assets are missing

### DIFF
--- a/app/src/main/java/com/hereliesaz/liperty/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/MainActivity.kt
@@ -691,14 +691,17 @@ class MainActivity : ComponentActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-        if (coreInitialized) {
-            cameraManager.shutdown()
-            faceLandmarkerHelper.close()
-            handGestureHelper.close()
-            laryngealSensor.stop()
-            vsrInference.close()
-            ssrInference.close()
-        }
+        // Per-field guards (not a single coreInitialized check): the try block
+        // in onCreate may throw partway through, leaving an arbitrary prefix of
+        // these fields initialized. Skipping them all would leak the ones that
+        // did get constructed.
+        if (::cameraManager.isInitialized) cameraManager.shutdown()
+        if (::faceLandmarkerHelper.isInitialized) faceLandmarkerHelper.close()
+        if (::handGestureHelper.isInitialized) handGestureHelper.close()
+        if (::laryngealSensor.isInitialized) laryngealSensor.stop()
+        if (::vsrInference.isInitialized) vsrInference.close()
+        if (::ssrInference.isInitialized) ssrInference.close()
+        if (::frameBuffer.isInitialized) frameBuffer.clearAndRecycle()
         if (::voiceManager.isInitialized) {
             voiceManager.stop()
             voiceManager.shutdown()

--- a/app/src/main/java/com/hereliesaz/liperty/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/MainActivity.kt
@@ -110,6 +110,12 @@ class MainActivity : ComponentActivity() {
     @Volatile private var frameCount = 0
     @Volatile private var calibrationCallback: ((Bitmap) -> Unit)? = null
 
+    // True only when the try block in onCreate completed without throwing.
+    // Gates every code path that touches the ML/camera lateinit fields so the
+    // app can still launch (and show the init-error Toast) when assets are
+    // missing instead of force-closing.
+    @Volatile private var coreInitialized = false
+
     // Tracks whether BC/EL was active before onPause so we can restore on resume
     @Volatile private var wasBCActiveBeforePause = false
     @Volatile private var wasELActiveBeforePause = false
@@ -168,15 +174,20 @@ class MainActivity : ComponentActivity() {
             // Auto-AVSR's encoder accepts variable T; 16 frames keeps cadence
             // close to the legacy VideoMAE pipeline.
             frameBuffer = FrameBuffer(capacity = 16)
+            coreInitialized = true
         } catch (e: Exception) {
             Log.e("MainActivity", "Failed to initialize components", e)
             Toast.makeText(this, getString(R.string.common_init_error, e.message ?: ""), Toast.LENGTH_LONG).show()
         }
 
-        // Initialize TFLite in background
-        lifecycleScope.launch(Dispatchers.Default) {
-            vsrInference.initialize()
-            ssrInference.initialize()
+        // Initialize TFLite in background — only if the lateinit fields above
+        // were successfully constructed. Touching them otherwise would throw
+        // UninitializedPropertyAccessException and crash the activity.
+        if (coreInitialized) {
+            lifecycleScope.launch(Dispatchers.Default) {
+                vsrInference.initialize()
+                ssrInference.initialize()
+            }
         }
 
         // Initialize VoiceManager
@@ -205,7 +216,7 @@ class MainActivity : ComponentActivity() {
                 onClearTranscript = {
                     transcriptionManager.clear()
                     updateTranscriptionUI()
-                    frameBuffer.clearAndRecycle()
+                    if (coreInitialized) frameBuffer.clearAndRecycle()
                 },
                 onSpeak = { speakText() },
                 onToggleBC = { toggleBCMode() },
@@ -219,17 +230,17 @@ class MainActivity : ComponentActivity() {
                 vsrSensitivity = vsrSensitivity.value,
                 onVsrSensitivityChange = { value ->
                     vsrSensitivity.value = value
-                    faceLandmarkerHelper.updateConfidence(value, value)
+                    if (coreInitialized) faceLandmarkerHelper.updateConfidence(value, value)
                 },
                 larynxSensitivity = larynxSensitivity.value,
                 onLarynxSensitivityChange = {
                     larynxSensitivity.value = it
-                    laryngealSensor.setSensitivity(it)
+                    if (coreInitialized) laryngealSensor.setSensitivity(it)
                 },
                 carrierF0 = carrierF0State.value,
                 onCarrierF0Change = { hz ->
                     carrierF0State.value = hz
-                    laryngealSensor.setCarrierF0(hz)
+                    if (coreInitialized) laryngealSensor.setCarrierF0(hz)
                 },
                 isDarkTheme = isDarkTheme.value,
                 onRegisterCalibrationCallback = { cb ->
@@ -254,6 +265,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onPause() {
         super.onPause()
+        if (!coreInitialized) return
         // Stop audio resources — camera stops automatically via CameraX lifecycle binding
         wasBCActiveBeforePause = isBCModeState.value
         wasELActiveBeforePause = isELModeState.value
@@ -267,6 +279,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onResume() {
         super.onResume()
+        if (!coreInitialized) return
         applySettings()
         // Restart camera if consent was previously granted
         val consentGranted = getSharedPreferences("LipertyPrefs", Context.MODE_PRIVATE)
@@ -302,6 +315,7 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun checkConsentAndStart() {
+        if (!coreInitialized) return
         val sharedPrefs = getSharedPreferences("LipertyPrefs", Context.MODE_PRIVATE)
         val consentGranted = sharedPrefs.getBoolean("consent_granted", false)
         val calibrationDone = sharedPrefs.getBoolean("calibration_complete", false)
@@ -339,6 +353,7 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun toggleCamera() {
+        if (!coreInitialized) return
         currentLensFacing = if (currentLensFacing == CameraSelector.LENS_FACING_BACK) {
             CameraSelector.LENS_FACING_FRONT
         } else {
@@ -348,6 +363,7 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun toggleBCMode() {
+        if (!coreInitialized) return
         if (isELModeState.value) {
             isBCModeState.value = false
             toggleELMode() // Mutually exclusive
@@ -386,6 +402,7 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun toggleELMode() {
+        if (!coreInitialized) return
         if (isBCModeState.value) {
             isELModeState.value = false
             toggleBCMode() // Mutually exclusive
@@ -409,6 +426,7 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun speakText() {
+        if (!::voiceManager.isInitialized) return
         // Use the text from the manager
         val text = transcriptionManager.getCurrentSentence()
         if (text.isNotEmpty()) {
@@ -417,6 +435,7 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun startCamera() {
+        if (!coreInitialized) return
         // We reuse the programmatically created previewView
         val analyzer = ImageAnalysis.Analyzer { imageProxy ->
             PerformanceMonitor.logFrame()
@@ -672,14 +691,18 @@ class MainActivity : ComponentActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-        cameraManager.shutdown()
-        faceLandmarkerHelper.close()
-        handGestureHelper.close()
-        laryngealSensor.stop()
-        vsrInference.close()
-        ssrInference.close()
-        voiceManager.stop()
-        voiceManager.shutdown()
+        if (coreInitialized) {
+            cameraManager.shutdown()
+            faceLandmarkerHelper.close()
+            handGestureHelper.close()
+            laryngealSensor.stop()
+            vsrInference.close()
+            ssrInference.close()
+        }
+        if (::voiceManager.isInitialized) {
+            voiceManager.stop()
+            voiceManager.shutdown()
+        }
     }
 
     // Removed: onInit(status: Int) is now handled by VoiceManager


### PR DESCRIPTION
## Summary

The app was force-closing on launch whenever the Auto-AVSR assets weren't present in `app/src/main/assets/` — i.e., whenever `setup_libs.sh` hadn't successfully pulled `unigram5000_units.txt` and `autoavsr_lrs3_visual_ctc.onnx` from `HereLiesAz/liperty-autoavsr-onnx`.

### Root cause

In `MainActivity.onCreate`:

1. The `try` block constructs every ML/camera lateinit (`cameraManager`, `vsrInference`, `ssrInference`, `frameBuffer`, etc.) and calls `VocabularyLoader.loadFromAssets(this, "unigram5000_units.txt", ...)`.
2. When the vocab file is absent the loader throws `FileNotFoundException`. The `catch` only logs and shows a Toast — none of the lateinit fields get assigned.
3. Two lines later, `lifecycleScope.launch(Dispatchers.Default) { vsrInference.initialize(); ssrInference.initialize() }` fires unconditionally, hits `UninitializedPropertyAccessException` on a background coroutine, and crashes the activity before the user ever sees the UI.

### Fix

Track init success with a single `coreInitialized` flag and gate every code path that touches the ML/camera lateinit fields:

- the post-init `lifecycleScope.launch` (the immediate crash)
- lifecycle methods: `onResume`, `onPause`, `onDestroy`
- user-facing callbacks: `toggleCamera`, `toggleBCMode`, `toggleELMode`, `onClearTranscript`, sensitivity / carrier-F0 sliders
- `checkConsentAndStart` and `startCamera`

`voiceManager` is initialized outside the `try` block, so it gets its own `::voiceManager.isInitialized` guard in `onDestroy` and `speakText`.

Net behavior when assets are missing: the existing init-error Toast still shows, the UI renders, button taps no-op, and the activity stays alive instead of force-closing.

## Test plan

- [ ] Install on a device WITHOUT running `setup_libs.sh` (or with the Auto-AVSR ONNX/vocab deleted from `assets/`) — app launches to UI, init-error Toast appears, no force-close.
- [ ] Install with all assets present — app launches normally, camera previews, VSR pipeline runs.
- [ ] Background/foreground and rotation transitions don't crash in either state.
- [ ] Tap each rail control (clear, switch camera, toggle BC, toggle EL, sensitivity sliders) in the broken-assets state — no crashes.

https://claude.ai/code/session_01Gmnee8RivoNUz4t6uT6KtV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gmnee8RivoNUz4t6uT6KtV)_