### PR TITLE
Fix remaining force-close paths: BLE Audio init + VoiceManager ctor

### DIFF
--- a/app/src/main/java/com/hereliesaz/liperty/LipertyApplication.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/LipertyApplication.kt
@@ -1,11 +1,20 @@
 package com.hereliesaz.liperty
 
 import android.app.Application
+import android.util.Log
 import com.hereliesaz.liperty.voicebox.BluetoothLEAudioManager
 
 class LipertyApplication : Application() {
     override fun onCreate() {
         super.onCreate()
-        BluetoothLEAudioManager.initialize(this)
+        // Anything that throws here force-closes the app before MainActivity
+        // ever runs. BluetoothLEAudioManager.initialize already self-protects,
+        // but wrap defensively too — a crash in the Application class is the
+        // worst possible UX.
+        try {
+            BluetoothLEAudioManager.initialize(this)
+        } catch (t: Throwable) {
+            Log.e("LipertyApplication", "BLE Audio init threw — ignoring", t)
+        }
     }
 }

--- a/app/src/main/java/com/hereliesaz/liperty/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/MainActivity.kt
@@ -190,13 +190,22 @@ class MainActivity : ComponentActivity() {
             }
         }
 
-        // Initialize VoiceManager
-        voiceManager = VoiceManager(this) { ready ->
-            if (ready) {
-                Log.i("MainActivity", "VoiceManager initialized.")
-            } else {
-                Log.e("MainActivity", "VoiceManager initialization failed.")
+        // Initialize VoiceManager. PocketTTSEngine's ctor calls
+        // OrtEnvironment.getEnvironment() as a property initializer, which
+        // triggers ONNX Runtime native-lib loading and throws RuntimeException
+        // if the .so isn't packaged. Without this guard, that takes down the
+        // whole activity — onDestroy already tolerates voiceManager being
+        // uninitialized (::voiceManager.isInitialized).
+        try {
+            voiceManager = VoiceManager(this) { ready ->
+                if (ready) {
+                    Log.i("MainActivity", "VoiceManager initialized.")
+                } else {
+                    Log.e("MainActivity", "VoiceManager initialization failed.")
+                }
             }
+        } catch (t: Throwable) {
+            Log.e("MainActivity", "VoiceManager construction failed — TTS/voice cloning disabled", t)
         }
 
         setContent {
@@ -375,7 +384,9 @@ class MainActivity : ComponentActivity() {
             isLipReadModeState.value = false
             laryngealSensor.setCarrierF0(carrierF0State.value)
             laryngealSensor.startBCMode(
-                onProcessedAudio = { pcmSamples -> voiceManager.playAudio(pcmSamples) },
+                onProcessedAudio = { pcmSamples ->
+                    if (::voiceManager.isInitialized) voiceManager.playAudio(pcmSamples)
+                },
                 onVoicingState = { isVoicing ->
                     // Visual feedback for voice activity could be added here
                 },
@@ -388,7 +399,7 @@ class MainActivity : ComponentActivity() {
                                 withContext(Dispatchers.Main) {
                                     transcriptionManager.appendText(result.text, result.confidence)
                                     updateTranscriptionUI()
-                                    voiceManager.speakStreaming(result.text)
+                                    if (::voiceManager.isInitialized) voiceManager.speakStreaming(result.text)
                                 }
                             }
                         }
@@ -412,7 +423,9 @@ class MainActivity : ComponentActivity() {
         
         if (newMode) {
             isLipReadModeState.value = false
-            laryngealSensor.startELMode { pcmSamples -> voiceManager.playAudio(pcmSamples) }
+            laryngealSensor.startELMode { pcmSamples ->
+                if (::voiceManager.isInitialized) voiceManager.playAudio(pcmSamples)
+            }
             // Badge UI shows "EL" state
         } else {
             laryngealSensor.stop()

--- a/app/src/main/java/com/hereliesaz/liperty/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/MainActivity.kt
@@ -206,6 +206,7 @@ class MainActivity : ComponentActivity() {
             }
         } catch (t: Throwable) {
             Log.e("MainActivity", "VoiceManager construction failed — TTS/voice cloning disabled", t)
+            Toast.makeText(this, getString(R.string.common_voice_unavailable), Toast.LENGTH_LONG).show()
         }
 
         setContent {

--- a/app/src/main/java/com/hereliesaz/liperty/voicebox/BluetoothLEAudioManager.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/voicebox/BluetoothLEAudioManager.kt
@@ -43,27 +43,43 @@ object BluetoothLEAudioManager {
 
     /**
      * Initializes the LE Audio profile proxy.
+     *
+     * Called from [com.hereliesaz.liperty.LipertyApplication.onCreate], which
+     * runs before any runtime permission has been granted on a fresh install.
+     * `getProfileProxy(LE_AUDIO)` requires BLUETOOTH_CONNECT on API 31+ and
+     * will throw SecurityException without it — taking the whole process down
+     * before MainActivity ever runs. We swallow every Throwable here so the
+     * absence of LE Audio routing degrades gracefully into "no LE Audio
+     * routing" instead of a force-close.
      */
     @SuppressLint("MissingPermission")
     fun initialize(context: Context) {
-        val bluetoothManager = context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
-        val adapter = bluetoothManager.adapter ?: return
+        try {
+            val bluetoothManager =
+                context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager ?: return
+            val adapter = bluetoothManager.adapter ?: return
 
-        adapter.getProfileProxy(context, object : BluetoothProfile.ServiceListener {
-            override fun onServiceConnected(profile: Int, proxy: BluetoothProfile) {
-                if (profile == BluetoothProfile.LE_AUDIO) {
-                    leAudioProxy = proxy as BluetoothLeAudio
-                    Log.i(TAG, "LE Audio Profile connected")
+            adapter.getProfileProxy(context, object : BluetoothProfile.ServiceListener {
+                override fun onServiceConnected(profile: Int, proxy: BluetoothProfile) {
+                    if (profile == BluetoothProfile.LE_AUDIO) {
+                        leAudioProxy = proxy as BluetoothLeAudio
+                        Log.i(TAG, "LE Audio Profile connected")
+                    }
                 }
-            }
 
-            override fun onServiceDisconnected(profile: Int) {
-                if (profile == BluetoothProfile.LE_AUDIO) {
-                    leAudioProxy = null
-                    Log.i(TAG, "LE Audio Profile disconnected")
+                override fun onServiceDisconnected(profile: Int) {
+                    if (profile == BluetoothProfile.LE_AUDIO) {
+                        leAudioProxy = null
+                        Log.i(TAG, "LE Audio Profile disconnected")
+                    }
                 }
-            }
-        }, BluetoothProfile.LE_AUDIO)
+            }, BluetoothProfile.LE_AUDIO)
+        } catch (t: Throwable) {
+            // SecurityException (no BLUETOOTH_CONNECT), IllegalArgumentException
+            // (LE_AUDIO unsupported pre-API 33), NoClassDefFoundError on very
+            // old devices — none of them should crash the app.
+            Log.w(TAG, "LE Audio proxy init failed; continuing without LE Audio routing", t)
+        }
     }
 
     /**

--- a/app/src/main/java/com/hereliesaz/liperty/voicebox/BluetoothLEAudioManager.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/voicebox/BluetoothLEAudioManager.kt
@@ -54,6 +54,14 @@ object BluetoothLEAudioManager {
      */
     @SuppressLint("MissingPermission")
     fun initialize(context: Context) {
+        // BluetoothProfile.LE_AUDIO and the BluetoothLeAudio class were both
+        // added in API 33. Skip outright on older devices — the cast to
+        // BluetoothLeAudio inside the listener would otherwise NoClassDefFoundError
+        // on a binder thread (where the outer try/catch can't reach it).
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            Log.i(TAG, "Pre-API 33 — LE Audio not available, skipping init")
+            return
+        }
         try {
             val bluetoothManager =
                 context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager ?: return
@@ -75,9 +83,8 @@ object BluetoothLEAudioManager {
                 }
             }, BluetoothProfile.LE_AUDIO)
         } catch (t: Throwable) {
-            // SecurityException (no BLUETOOTH_CONNECT), IllegalArgumentException
-            // (LE_AUDIO unsupported pre-API 33), NoClassDefFoundError on very
-            // old devices — none of them should crash the app.
+            // SecurityException (no BLUETOOTH_CONNECT) is the most common; also
+            // catches NoClassDefFoundError / IllegalArgumentException defensively.
             Log.w(TAG, "LE Audio proxy init failed; continuing without LE Audio routing", t)
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="common_stop">STOP</string>
     <string name="common_permissions_denied">Permissions denied: %1$s</string>
     <string name="common_init_error">Initialization error: %1$s</string>
+    <string name="common_voice_unavailable">Voice features unavailable — TTS and voice cloning disabled.</string>
     <string name="common_calibration_prompt">Please personalize the model for better accuracy.</string>
     <string name="format_percent">%1$d%%</string>
     <string name="format_hz">%1$d Hz</string>


### PR DESCRIPTION
## Summary

Follow-up to #83. The user reports the app is still force-closing on launch. PR #83 only fixed the case where ML asset initialization throws and leaves the lateinit ML fields uninitialized. There were still two unguarded crash paths that fire **before MainActivity is usable**:

### 1. Process-level crash from BLE Audio init in the Application class

```
LipertyApplication.onCreate()
  -> BluetoothLEAudioManager.initialize(this)
     -> adapter.getProfileProxy(context, listener, BluetoothProfile.LE_AUDIO)
```

`getProfileProxy(LE_AUDIO)` requires `BLUETOOTH_CONNECT` on API 31+. On a fresh install that permission **isn't granted yet** (the request happens later in `MainActivity`), so this throws `SecurityException` from the Application class — taking the entire process down before any UI shows. `@SuppressLint("MissingPermission")` is lint-only, not runtime protection.

Wrapping the body of `initialize()` and the call site in `LipertyApplication` in `try { ... } catch (t: Throwable)` so missing LE Audio routing degrades gracefully into "no LE Audio routing" instead of a force-close. The catch also covers `IllegalArgumentException` (LE_AUDIO unsupported pre-API 33) and `NoClassDefFoundError` on very old devices.

### 2. Activity-level crash from VoiceManager construction

```
MainActivity.onCreate
  -> voiceManager = VoiceManager(this) {...}      // ← outside the try block
     -> private val pocketTts: PocketTTSEngine = PocketTTSEngine(context)
        -> private val ortEnv = OrtEnvironment.getEnvironment()  // ← native lib load
```

`OrtEnvironment.getEnvironment()` triggers ONNX Runtime native-lib loading and throws `RuntimeException` if `libonnxruntime.so` isn't packaged. This call site sits **outside** the existing protective `try` block, so it crashes the activity instantly.

Wrapping `voiceManager` construction in `try/catch`. `onDestroy` already tolerates `::voiceManager.isInitialized` being false. Also gating the BC/EL audio playback callbacks on `::voiceManager.isInitialized` so toggling them doesn't NPE if VoiceManager construction failed but ML init succeeded.

## Why this PR is necessary on top of #83

The earlier flag (`coreInitialized`) only protected the ML/camera lateinits. It did not address:
- crashes upstream of `MainActivity` (the Application class)
- crashes from `voiceManager` construction (which is outside the try block by design — it doesn't depend on Auto-AVSR assets)

## Test plan

- [ ] Fresh install on API 33+ device with `BLUETOOTH_CONNECT` not yet granted — app launches to UI, no force-close from BLE Audio init.
- [ ] Install built without ONNX Runtime native lib (or with the asset model files removed) — app launches, init-error toast or BC/EL toggles no-op silently, no force-close.
- [ ] Pre-API 33 device — `BluetoothProfile.LE_AUDIO` constant resolves but `getProfileProxy` returns false / throws — app still launches.
- [ ] All assets present → normal startup still works.
- [ ] Toggle BC/EL with VoiceManager intentionally broken → no crash; transcription still updates.

https://claude.ai/code/session_01Gmnee8RivoNUz4t6uT6KtV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gmnee8RivoNUz4t6uT6KtV)_