### PR TITLE
Address PR #93 review feedback: WavHeader util + streaming + UX polish

### DIFF
--- a/app/src/main/java/com/hereliesaz/liperty/ui/VoiceCoachScreen.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/ui/VoiceCoachScreen.kt
@@ -42,11 +42,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.hereliesaz.liperty.R
 import com.hereliesaz.liperty.voicebox.VoiceViewModel
 import com.hereliesaz.liperty.voicebox.cloning.VoiceQualityTier
 
@@ -157,8 +159,12 @@ fun VoiceCoachScreen(
         )
 
         // ── Script card ──────────────────────────────────────────
-        val script = remember(state.clipCount) {
-            HARVARD_PROMPTS[state.clipCount % HARVARD_PROMPTS.size]
+        // Tied to promptIndex (not clipCount) so a discard leaves
+        // the user on the same prompt they just attempted, ready to
+        // retry. The VM advances promptIndex on successful capture
+        // only — see VoiceViewModel.recomputeCoachQualityState.
+        val script = remember(state.promptIndex) {
+            HARVARD_PROMPTS[state.promptIndex % HARVARD_PROMPTS.size]
         }
         Card(
             modifier = Modifier.fillMaxWidth(),
@@ -297,7 +303,11 @@ private fun QualityTierCard(
                     fontWeight = FontWeight.Bold,
                 )
                 Text(
-                    text = "$clipCount clip(s) · ${totalSeconds}s",
+                    text = "${pluralStringResource(
+                        id = R.plurals.voice_coach_clip_count_inline,
+                        count = clipCount,
+                        clipCount,
+                    )} · ${totalSeconds}s",
                     color = Color(0xFF808099),
                     fontSize = 12.sp,
                 )
@@ -381,7 +391,11 @@ private fun CapturedClipsList(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
-                    text = "Captured: $clipCount clip(s)",
+                    text = pluralStringResource(
+                        id = R.plurals.voice_coach_clips_captured,
+                        count = clipCount,
+                        clipCount,
+                    ),
                     color = Color.White,
                     fontSize = 12.sp,
                 )

--- a/app/src/main/java/com/hereliesaz/liperty/voicebox/PocketTTSEngine.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/voicebox/PocketTTSEngine.kt
@@ -7,8 +7,6 @@ import android.content.Context
 import android.util.Log
 import java.io.File
 import java.io.Serializable
-import java.nio.ByteBuffer
-import java.nio.ByteOrder
 import java.nio.FloatBuffer
 import java.nio.LongBuffer
 
@@ -121,6 +119,23 @@ class PocketTTSEngine(private val context: Context) {
          * higher = stronger timbre transfer but more artifacts.
          */
         const val DEFAULT_TAU: Float = 0.3f
+
+        /**
+         * Hard cap on the WAV data chunk we'll decode from a single
+         * reference file. 24 kHz mono 16-bit PCM = 48 KB/s, so this
+         * is ~14 minutes of audio per clip — well past the OpenVoice
+         * v2 sweet spot of 5-30 s. Guards against malicious or
+         * malformed headers declaring multi-GB data chunks.
+         */
+        const val MAX_REFERENCE_AUDIO_BYTES: Long = 40L * 1024L * 1024L
+
+        /**
+         * I/O buffer size used when streaming PCM samples through
+         * the mono downmixer. Sized to handle ~85 ms of 48 kHz
+         * stereo audio per read while staying nicely under the
+         * Android L1 cache for typical mid-range hardware.
+         */
+        private const val STREAM_BUFFER_BYTES = 32_768
     }
 
     /**
@@ -317,74 +332,137 @@ class PocketTTSEngine(private val context: Context) {
     }
 
     /**
-     * Minimal WAV reader (16-bit PCM mono). Honors the sample rate
-     * declared in the header so a user-supplied 16/22.05/44.1/48 kHz
-     * clip (voicemail, video extract, voice memo) can be resampled
-     * to the 24 kHz the extractor expects.
+     * Streaming WAV reader (16-bit PCM, any channel count). Honors
+     * the sample rate declared in the header so a user-supplied
+     * 16/22.05/44.1/48 kHz clip (voicemail, video extract, voice
+     * memo) is resampled to the 24 kHz the extractor expects.
+     *
+     * Reads at most the header up front (a few hundred bytes via
+     * [WavHeader.read]), then streams the data chunk into a
+     * `FloatArray` of mono samples — never holding the full file
+     * in a `ByteArray`. This keeps memory pressure proportional to
+     * the audio length rather than the file size, which matters
+     * for long voicemails or long video extracts.
      *
      * Falls back to assuming 24 kHz mono PCM if the header is
      * unparseable, matching the previous behavior.
+     *
+     * Bounded at [MAX_REFERENCE_AUDIO_BYTES] to avoid a malicious
+     * or corrupted header that declares a multi-GB data chunk
+     * from OOM'ing the app.
      */
-    private fun readWavFile(file: File): Pair<FloatArray, Int> {
-        val bytes = file.readBytes()
-        if (bytes.size < 44 || String(bytes, 0, 4) != "RIFF") {
-            // Not a WAV header — assume raw 16-bit PCM at 24 kHz.
-            return decodePcm16(bytes, 0) to SE_EXTRACTOR_SAMPLE_RATE_HZ
+    internal fun readWavFile(file: File): Pair<FloatArray, Int> {
+        val header = WavHeader.read(file)
+        if (header == null) {
+            // Not a parseable RIFF/WAVE — fall back to raw 16-bit
+            // PCM at the extractor's native rate. Read a bounded
+            // window from the file.
+            val raw = readBoundedBytes(file, 0L, MAX_REFERENCE_AUDIO_BYTES)
+            return decodePcm16(raw) to SE_EXTRACTOR_SAMPLE_RATE_HZ
         }
-        val bb = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
-        val sampleRate = bb.getInt(24)
-        val numChannels = bb.getShort(22).toInt()
-        val bitsPerSample = bb.getShort(34).toInt()
-
-        // Find the "data" subchunk — its offset is not always 44.
-        var dataOffset = 12
-        while (dataOffset < bytes.size - 8) {
-            val tag = String(bytes, dataOffset, 4)
-            val size = bb.getInt(dataOffset + 4)
-            if (tag == "data") {
-                dataOffset += 8
-                break
-            }
-            dataOffset += 8 + size
+        if (header.bitsPerSample != 16) {
+            Log.w(
+                TAG,
+                "WAV bitsPerSample=${header.bitsPerSample} (only 16 supported); " +
+                    "falling back to raw decode."
+            )
+            val raw = readBoundedBytes(file, header.dataOffsetBytes, MAX_REFERENCE_AUDIO_BYTES)
+            return decodePcm16(raw) to header.sampleRate
         }
-        if (dataOffset >= bytes.size) {
-            return decodePcm16(bytes, 44) to SE_EXTRACTOR_SAMPLE_RATE_HZ
-        }
-
-        if (bitsPerSample != 16) {
-            Log.w(TAG, "WAV bitsPerSample=$bitsPerSample (only 16 supported); falling back.")
-        }
-        val mono = decodePcm16Channels(bytes, dataOffset, numChannels)
-        return mono to sampleRate
+        val maxDataBytes = MAX_REFERENCE_AUDIO_BYTES.coerceAtMost(header.dataSizeBytes)
+        val mono = decodePcm16Streaming(file, header, maxDataBytes)
+        return mono to header.sampleRate
     }
 
-    private fun decodePcm16(bytes: ByteArray, headerOffset: Int): FloatArray {
-        val n = maxOf(0, (bytes.size - headerOffset) / 2)
+    /**
+     * Streams [maxBytes] of 16-bit PCM data starting at
+     * [header]`.dataOffsetBytes`, downmixing to mono on the fly.
+     * Allocates exactly one `FloatArray` of the final mono length —
+     * no transient `ByteArray` of the full data chunk.
+     */
+    private fun decodePcm16Streaming(
+        file: File,
+        header: WavHeader,
+        maxBytes: Long,
+    ): FloatArray {
+        val channels = header.channels.coerceAtLeast(1)
+        val frameBytes = channels * 2
+        val totalFrames = (maxBytes / frameBytes.toLong()).toInt()
+        val out = FloatArray(totalFrames)
+        val buf = ByteArray(STREAM_BUFFER_BYTES - (STREAM_BUFFER_BYTES % frameBytes))
+        var frameIdx = 0
+
+        file.inputStream().buffered().use { input ->
+            // Skip past RIFF + chunks up to the start of data.
+            var skipRemaining = header.dataOffsetBytes
+            while (skipRemaining > 0) {
+                val skipped = input.skip(skipRemaining)
+                if (skipped <= 0) break
+                skipRemaining -= skipped
+            }
+            var consumedFromData = 0L
+            while (frameIdx < totalFrames) {
+                val want = minOf(buf.size.toLong(), maxBytes - consumedFromData).toInt()
+                if (want <= 0) break
+                val read = input.read(buf, 0, want)
+                if (read <= 0) break
+                consumedFromData += read
+                // Decode this chunk into the mono FloatArray.
+                var byteIdx = 0
+                val readFrames = read / frameBytes
+                for (i in 0 until readFrames) {
+                    if (frameIdx >= totalFrames) break
+                    var sum = 0
+                    for (c in 0 until channels) {
+                        val lo = buf[byteIdx].toInt() and 0xFF
+                        val hi = buf[byteIdx + 1].toInt()
+                        sum += ((hi shl 8) or lo).toShort().toInt()
+                        byteIdx += 2
+                    }
+                    out[frameIdx++] = (sum.toFloat() / channels) / Short.MAX_VALUE
+                }
+            }
+        }
+        // If we read fewer frames than expected (truncated file),
+        // return only the populated prefix.
+        return if (frameIdx == totalFrames) out else out.copyOf(frameIdx)
+    }
+
+    /**
+     * Reads at most [maxBytes] starting at [offset] from [file].
+     * Used only on the unparseable-header fallback path.
+     */
+    private fun readBoundedBytes(file: File, offset: Long, maxBytes: Long): ByteArray {
+        val capped = maxBytes.coerceAtMost(file.length() - offset).coerceAtLeast(0L).toInt()
+        if (capped <= 0) return ByteArray(0)
+        val out = ByteArray(capped)
+        file.inputStream().buffered().use { input ->
+            var remaining = offset
+            while (remaining > 0) {
+                val skipped = input.skip(remaining)
+                if (skipped <= 0) break
+                remaining -= skipped
+            }
+            var read = 0
+            while (read < capped) {
+                val n = input.read(out, read, capped - read)
+                if (n <= 0) break
+                read += n
+            }
+            if (read < capped) return out.copyOf(read)
+        }
+        return out
+    }
+
+    private fun decodePcm16(bytes: ByteArray): FloatArray {
+        val n = bytes.size / 2
         val out = FloatArray(n)
-        var idx = headerOffset
+        var idx = 0
         for (i in 0 until n) {
             val sample = ((bytes[idx + 1].toInt() shl 8) or
                 (bytes[idx].toInt() and 0xFF)).toShort()
             out[i] = sample.toFloat() / Short.MAX_VALUE
             idx += 2
-        }
-        return out
-    }
-
-    private fun decodePcm16Channels(bytes: ByteArray, offset: Int, channels: Int): FloatArray {
-        if (channels <= 1) return decodePcm16(bytes, offset)
-        val frameBytes = channels * 2
-        val frames = (bytes.size - offset) / frameBytes
-        val out = FloatArray(frames)
-        for (i in 0 until frames) {
-            var sum = 0
-            val frameStart = offset + i * frameBytes
-            for (c in 0 until channels) {
-                val s = ((bytes[frameStart + c * 2 + 1].toInt() shl 8) or
-                    (bytes[frameStart + c * 2].toInt() and 0xFF)).toShort()
-                sum += s.toInt()
-            }
-            out[i] = (sum.toFloat() / channels) / Short.MAX_VALUE
         }
         return out
     }

--- a/app/src/main/java/com/hereliesaz/liperty/voicebox/PocketTTSEngine.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/voicebox/PocketTTSEngine.kt
@@ -392,7 +392,7 @@ class PocketTTSEngine(private val context: Context) {
         val buf = ByteArray(STREAM_BUFFER_BYTES - (STREAM_BUFFER_BYTES % frameBytes))
         var frameIdx = 0
 
-        file.inputStream().buffered().use { input ->
+        file.inputStream().use { input ->
             // Skip past RIFF + chunks up to the start of data.
             var skipRemaining = header.dataOffsetBytes
             while (skipRemaining > 0) {

--- a/app/src/main/java/com/hereliesaz/liperty/voicebox/VoiceViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/voicebox/VoiceViewModel.kt
@@ -45,6 +45,15 @@ data class CoachState(
     val totalSpeechSeconds: Int = 0,
     /** Discrete quality band, recomputed after every clip. */
     val qualityTier: VoiceQualityTier = VoiceQualityTier.NONE,
+    /**
+     * Pointer into the Harvard-sentence prompt list. Advances on
+     * successful capture (`recomputeCoachQualityState(advancePrompt = true)`)
+     * but stays put on discard, so retrying lands the user back on
+     * the same prompt they just attempted. Decoupling this from
+     * [clipCount] is what prevents the prompt from "jumping" when
+     * the user discards a bad clip.
+     */
+    val promptIndex: Int = 0,
     /** True while the [VoiceRecorder] is actively capturing. */
     val isRecording: Boolean = false,
     /** True between "Save" tap and HF/disk write completing. */
@@ -409,7 +418,13 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
                 // resamples to 24 kHz at extraction time and
                 // wavDurationMs() reports the true duration.
                 coachedClips.add(file)
-                recomputeCoachQualityState(message = "Captured clip ${coachedClips.size}.")
+                // Advance prompt only on successful capture; discard
+                // leaves promptIndex alone so retrying lands on the
+                // same sentence the user just attempted.
+                recomputeCoachQualityState(
+                    message = "Captured clip ${coachedClips.size}.",
+                    advancePrompt = true,
+                )
             },
             onError = { msg ->
                 _coachState.value = _coachState.value.copy(
@@ -497,46 +512,51 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
         coachedClips.forEach { it.delete() }
     }
 
-    private fun recomputeCoachQualityState(message: String) {
+    /**
+     * Recomputes the derived fields of [CoachState] (count, total
+     * seconds, quality tier) from the on-disk clip list and merges
+     * them with [message] / [advancePrompt].
+     *
+     * - Always clears any prior `error` because this helper is only
+     *   reached on success paths (clip recorded, clip discarded).
+     *   Leaving a stale error in state would freeze the status line
+     *   in error styling after the next successful recording.
+     * - [advancePrompt] = true after a successful capture; the
+     *   prompt index moves forward so the user sees a new sentence.
+     *   On discard it's false, so the user lands back on the same
+     *   prompt as their just-discarded clip and can retry it.
+     */
+    private fun recomputeCoachQualityState(message: String, advancePrompt: Boolean = false) {
         val clips = coachedClips.size
         val totalSec = (coachedClips.sumOf { wavDurationMs(it) } / 1000L).toInt()
         val tier = VoiceQualityTier.compute(clips, totalSec)
-        _coachState.value = _coachState.value.copy(
+        val prev = _coachState.value
+        _coachState.value = prev.copy(
             isRecording = false,
             clipCount = clips,
             totalSpeechSeconds = totalSec,
             qualityTier = tier,
-            statusMessage = message
+            promptIndex = if (advancePrompt) prev.promptIndex + 1 else prev.promptIndex,
+            statusMessage = message,
+            error = null,
         )
     }
 
     /**
-     * Reads a 16-bit PCM WAV's data-chunk length without decoding
-     * the audio. Falls back to length/2/16000 if the header isn't
-     * a standard 44-byte RIFF.
+     * Header-only duration for a recorded WAV clip via [WavHeader].
+     * Streams at most a few hundred bytes rather than loading the
+     * whole file — relevant if the user backgrounds the app mid-
+     * session and the OS swaps out memory.
+     *
+     * Falls back to assuming 16 kHz mono raw PCM (matching what
+     * [VoiceRecorder] writes) when the header isn't parseable.
      */
     private fun wavDurationMs(file: File): Long {
-        val bytes = try { file.readBytes() } catch (_: Exception) { return 0L }
-        if (bytes.size < 44) return 0L
-        if (String(bytes, 0, 4) != "RIFF") {
-            // Raw PCM — assume 16 kHz mono.
-            return (bytes.size / 2L) * 1000L / 16_000L
-        }
-        val bb = java.nio.ByteBuffer.wrap(bytes).order(java.nio.ByteOrder.LITTLE_ENDIAN)
-        val sampleRate = bb.getInt(24).coerceAtLeast(1)
-        val bitsPerSample = bb.getShort(34).toInt().coerceAtLeast(1)
-        // Find data chunk size.
-        var dataSize = bytes.size - 44
-        var off = 12
-        while (off + 8 < bytes.size) {
-            val tag = String(bytes, off, 4)
-            val size = bb.getInt(off + 4)
-            if (tag == "data") { dataSize = size; break }
-            off += 8 + size
-        }
-        val bytesPerSample = bitsPerSample / 8
-        val samples = dataSize.toLong() / bytesPerSample.coerceAtLeast(1)
-        return samples * 1000L / sampleRate
+        val header = WavHeader.read(file)
+        if (header != null) return header.durationMs
+        val len = try { file.length() } catch (_: Exception) { return 0L }
+        if (len <= 44) return 0L
+        return ((len - 44) / 2L) * 1000L / 16_000L
     }
 
     // ── Existing Recording Flow (kept for backward compat) ──────────────

--- a/app/src/main/java/com/hereliesaz/liperty/voicebox/WavHeader.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/voicebox/WavHeader.kt
@@ -1,0 +1,177 @@
+package com.hereliesaz.liperty.voicebox
+
+import java.io.DataInputStream
+import java.io.EOFException
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * Shared WAV (RIFF) metadata reader.
+ *
+ * Streams just the header and chunk boundary bytes rather than
+ * loading the entire file — important for arbitrary user-supplied
+ * reference audio (long voicemails, video extracts), where the
+ * previous full-file `readBytes()` approach risked OOM on multi-MB
+ * inputs.
+ *
+ * The on-disk WAV format is a "RIFF" container of one or more
+ * little-endian chunks: `RIFF<size>WAVE` followed by an "fmt "
+ * chunk (sample rate / channels / bits per sample) and a "data"
+ * chunk (the PCM samples). Other chunks (LIST/INFO, JUNK, etc.)
+ * may appear between fmt and data and must be skipped over.
+ *
+ * Both [PocketTTSEngine.readWavFile] and
+ * [com.hereliesaz.liperty.voicebox.VoiceViewModel] consume this
+ * to avoid drift between the two parsers.
+ */
+data class WavHeader(
+    /** Sample rate in Hz from the `fmt ` chunk. */
+    val sampleRate: Int,
+    /** Channel count from the `fmt ` chunk. */
+    val channels: Int,
+    /** Bits per sample from the `fmt ` chunk. */
+    val bitsPerSample: Int,
+    /** Byte offset of the first sample (just past the `data` chunk header). */
+    val dataOffsetBytes: Long,
+    /** Declared size in bytes of the data chunk. */
+    val dataSizeBytes: Long,
+) {
+    /** Duration of the audio data in milliseconds. */
+    val durationMs: Long
+        get() {
+            val bytesPerSample = (bitsPerSample / 8).coerceAtLeast(1)
+            val frames = dataSizeBytes / bytesPerSample.toLong() / channels.coerceAtLeast(1).toLong()
+            return frames * 1000L / sampleRate.coerceAtLeast(1).toLong()
+        }
+
+    companion object {
+        /**
+         * Reads the header of [file] without loading the full payload.
+         * Returns null if [file] is not a parseable PCM RIFF/WAVE
+         * stream (callers can then fall back to assuming raw PCM
+         * at a known rate / channel count).
+         *
+         * Streams at most a few hundred bytes (RIFF header + fmt
+         * chunk + any intermediate non-data chunks' headers).
+         */
+        fun read(file: File): WavHeader? = try {
+            file.inputStream().buffered().use { read(it) }
+        } catch (_: IOException) {
+            null
+        }
+
+        /**
+         * Same as [read] but takes a pre-opened stream so callers
+         * that already have a [java.io.FileInputStream] (or want
+         * to inject a fixture in tests) don't have to reopen.
+         * Caller owns closing the stream.
+         */
+        fun read(stream: InputStream): WavHeader? {
+            val dis = DataInputStream(stream)
+            try {
+                // RIFF header.
+                val riff = readAscii(dis, 4)
+                if (riff != "RIFF") return null
+                readLE32(dis) // chunkSize, ignored
+                val wave = readAscii(dis, 4)
+                if (wave != "WAVE") return null
+
+                var bytesSeen = 12L
+                var sampleRate = 0
+                var channels = 0
+                var bitsPerSample = 0
+                var dataSize = 0L
+                var dataOffset = -1L
+
+                while (true) {
+                    val tag = try { readAscii(dis, 4) } catch (_: EOFException) { return null }
+                    val size = readLE32(dis).toLong() and 0xFFFF_FFFFL
+                    bytesSeen += 8
+                    when (tag) {
+                        "fmt " -> {
+                            // Standard PCM fmt chunk: 16 bytes; some
+                            // encoders write 18 or 40. Read what we
+                            // need then skip any trailing extension.
+                            if (size < 16) return null
+                            readLE16(dis) // audio format (1 = PCM)
+                            channels = readLE16(dis)
+                            sampleRate = readLE32(dis)
+                            readLE32(dis) // byte rate
+                            readLE16(dis) // block align
+                            bitsPerSample = readLE16(dis)
+                            val consumed = 16L
+                            if (size > consumed) skipFully(dis, size - consumed)
+                            bytesSeen += size
+                        }
+                        "data" -> {
+                            dataSize = size
+                            dataOffset = bytesSeen
+                            // Done — header parse complete. Don't
+                            // skip the data; the caller may want to
+                            // stream it. We've reached the data
+                            // boundary, that's enough.
+                            return if (sampleRate <= 0 || channels <= 0) {
+                                null
+                            } else {
+                                WavHeader(
+                                    sampleRate = sampleRate,
+                                    channels = channels,
+                                    bitsPerSample = bitsPerSample,
+                                    dataOffsetBytes = dataOffset,
+                                    dataSizeBytes = dataSize,
+                                )
+                            }
+                        }
+                        else -> {
+                            // Unknown chunk (LIST/INFO, JUNK, etc.) — skip.
+                            skipFully(dis, size)
+                            bytesSeen += size
+                        }
+                    }
+                }
+                @Suppress("UNREACHABLE_CODE")
+                null
+            } catch (_: EOFException) {
+                null
+            } catch (_: IOException) {
+                null
+            }
+        }
+
+        // ── primitives ─────────────────────────────────────────────
+
+        private fun readAscii(dis: DataInputStream, n: Int): String {
+            val buf = ByteArray(n)
+            dis.readFully(buf)
+            return String(buf, Charsets.US_ASCII)
+        }
+
+        private fun readLE16(dis: DataInputStream): Int {
+            val buf = ByteArray(2)
+            dis.readFully(buf)
+            return ByteBuffer.wrap(buf).order(ByteOrder.LITTLE_ENDIAN).short.toInt() and 0xFFFF
+        }
+
+        private fun readLE32(dis: DataInputStream): Int {
+            val buf = ByteArray(4)
+            dis.readFully(buf)
+            return ByteBuffer.wrap(buf).order(ByteOrder.LITTLE_ENDIAN).int
+        }
+
+        /**
+         * DataInputStream.skip() is allowed to skip fewer bytes than
+         * requested; loop until done or EOF.
+         */
+        private fun skipFully(dis: DataInputStream, count: Long) {
+            var remaining = count
+            while (remaining > 0) {
+                val skipped = dis.skip(remaining)
+                if (skipped <= 0) break
+                remaining -= skipped
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/hereliesaz/liperty/voicebox/cloning/VoiceQualityTier.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/voicebox/cloning/VoiceQualityTier.kt
@@ -56,6 +56,10 @@ enum class VoiceQualityTier(
          * argument requires multiple clips, not just more audio).
          */
         fun compute(clipCount: Int, totalSeconds: Int): VoiceQualityTier {
+            // `entries` returns the cached immutable enum list rather
+            // than allocating a new array per call like `values()`
+            // does — matters here because compute() runs on every
+            // recomposition of the live tier indicator.
             val candidates = entries.filter { tier ->
                 clipCount >= tier.minClips && totalSeconds >= tier.minSeconds
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -132,4 +132,14 @@
     <string name="cd_play_sample">Play sample</string>
     <string name="cd_selected">Selected</string>
     <string name="cd_preview_voice">Preview voice</string>
+
+    <!-- Voice Coach (live quality-tier multi-clip recording) -->
+    <plurals name="voice_coach_clips_captured">
+        <item quantity="one">Captured: %d clip</item>
+        <item quantity="other">Captured: %d clips</item>
+    </plurals>
+    <plurals name="voice_coach_clip_count_inline">
+        <item quantity="one">%d clip</item>
+        <item quantity="other">%d clips</item>
+    </plurals>
 </resources>

--- a/app/src/test/java/com/hereliesaz/liperty/voicebox/VoiceViewModelTest.kt
+++ b/app/src/test/java/com/hereliesaz/liperty/voicebox/VoiceViewModelTest.kt
@@ -184,11 +184,31 @@ class VoiceViewModelTest {
         assertEquals(0, state.clipCount)
         assertEquals(0, state.totalSpeechSeconds)
         assertEquals(VoiceQualityTier.NONE, state.qualityTier)
+        assertEquals(0, state.promptIndex)
         assertFalse(state.isRecording)
         assertFalse(state.isSaving)
         assertFalse(state.isSaved)
         assertNull(state.savedProfileName)
         assertNull(state.error)
+    }
+
+    @Test
+    fun `CoachState copy preserves promptIndex when advancePrompt is not set`() {
+        // recomputeCoachQualityState() with advancePrompt = false
+        // (the discard path) must leave promptIndex untouched so the
+        // user lands back on the same Harvard sentence after discard.
+        val mid = CoachState(promptIndex = 4, clipCount = 5)
+        val afterDiscard = mid.copy(clipCount = 4)
+        assertEquals(4, afterDiscard.promptIndex)
+    }
+
+    @Test
+    fun `CoachState copy can reset error explicitly`() {
+        // recomputeCoachQualityState() clears `error` on every
+        // success path. Verify the copy semantics support this.
+        val errored = CoachState(error = "Recording failed")
+        val recovered = errored.copy(error = null, statusMessage = "Captured clip 1.")
+        assertNull(recovered.error)
     }
 
     @Test

--- a/app/src/test/java/com/hereliesaz/liperty/voicebox/WavHeaderTest.kt
+++ b/app/src/test/java/com/hereliesaz/liperty/voicebox/WavHeaderTest.kt
@@ -1,0 +1,173 @@
+package com.hereliesaz.liperty.voicebox
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * Tests for [WavHeader] — the streaming RIFF/WAVE header reader
+ * shared by [PocketTTSEngine.readWavFile] and
+ * [com.hereliesaz.liperty.voicebox.VoiceViewModel.wavDurationMs].
+ *
+ * Pure JUnit — no Android dependencies. Builds canonical WAV byte
+ * streams in memory and asserts the parsed fields.
+ */
+class WavHeaderTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    // ── synthetic WAV builder ─────────────────────────────────────
+
+    /**
+     * Builds a minimal-but-valid RIFF/WAVE byte stream with the
+     * given format chunk and a `data` chunk filled with zeros.
+     */
+    private fun buildWav(
+        sampleRate: Int,
+        channels: Int,
+        bitsPerSample: Int,
+        dataBytes: Int,
+        extraChunkBeforeData: Pair<String, ByteArray>? = null,
+    ): ByteArray {
+        val fmtSize = 16
+        val extraSize = extraChunkBeforeData?.let { 8 + it.second.size } ?: 0
+        val riffSize = 4 + (8 + fmtSize) + extraSize + (8 + dataBytes)
+        val buf = ByteBuffer.allocate(8 + riffSize).order(ByteOrder.LITTLE_ENDIAN)
+        buf.put("RIFF".toByteArray(Charsets.US_ASCII))
+        buf.putInt(riffSize)
+        buf.put("WAVE".toByteArray(Charsets.US_ASCII))
+        // fmt chunk
+        buf.put("fmt ".toByteArray(Charsets.US_ASCII))
+        buf.putInt(fmtSize)
+        buf.putShort(1) // PCM
+        buf.putShort(channels.toShort())
+        buf.putInt(sampleRate)
+        buf.putInt(sampleRate * channels * bitsPerSample / 8) // byte rate
+        buf.putShort((channels * bitsPerSample / 8).toShort()) // block align
+        buf.putShort(bitsPerSample.toShort())
+        // optional spurious chunk
+        extraChunkBeforeData?.let { (tag, payload) ->
+            buf.put(tag.toByteArray(Charsets.US_ASCII))
+            buf.putInt(payload.size)
+            buf.put(payload)
+        }
+        // data chunk
+        buf.put("data".toByteArray(Charsets.US_ASCII))
+        buf.putInt(dataBytes)
+        buf.put(ByteArray(dataBytes))
+        return buf.array()
+    }
+
+    // ── happy path ─────────────────────────────────────────────────
+
+    @Test
+    fun `reads canonical 16 kHz mono 16-bit header`() {
+        val bytes = buildWav(sampleRate = 16_000, channels = 1, bitsPerSample = 16, dataBytes = 32_000)
+        val h = WavHeader.read(ByteArrayInputStream(bytes))
+        assertNotNull(h)
+        assertEquals(16_000, h!!.sampleRate)
+        assertEquals(1, h.channels)
+        assertEquals(16, h.bitsPerSample)
+        assertEquals(32_000L, h.dataSizeBytes)
+        // data offset = 12 (RIFF/size/WAVE) + 8 (fmt header) + 16 (fmt body) = 36
+        assertEquals(36L, h.dataOffsetBytes)
+    }
+
+    @Test
+    fun `duration math for 1 second of 16 kHz mono 16-bit`() {
+        // 16000 frames * 2 bytes/frame = 32000 data bytes → 1000 ms.
+        val bytes = buildWav(sampleRate = 16_000, channels = 1, bitsPerSample = 16, dataBytes = 32_000)
+        val h = WavHeader.read(ByteArrayInputStream(bytes))!!
+        assertEquals(1_000L, h.durationMs)
+    }
+
+    @Test
+    fun `duration math for 0_5 seconds of 24 kHz stereo 16-bit`() {
+        // 12000 frames * 4 bytes/frame = 48000 data bytes → 500 ms.
+        val bytes = buildWav(sampleRate = 24_000, channels = 2, bitsPerSample = 16, dataBytes = 48_000)
+        val h = WavHeader.read(ByteArrayInputStream(bytes))!!
+        assertEquals(2, h.channels)
+        assertEquals(500L, h.durationMs)
+    }
+
+    // ── chunk skipping ─────────────────────────────────────────────
+
+    @Test
+    fun `skips spurious LIST chunk before data`() {
+        // Some authoring tools insert LIST/INFO metadata between
+        // the fmt chunk and the data chunk — the parser must skip
+        // them and still report the right offsets.
+        val bytes = buildWav(
+            sampleRate = 16_000, channels = 1, bitsPerSample = 16, dataBytes = 32_000,
+            extraChunkBeforeData = "LIST" to ByteArray(64) { 0xAA.toByte() },
+        )
+        val h = WavHeader.read(ByteArrayInputStream(bytes))!!
+        assertEquals(16_000, h.sampleRate)
+        assertEquals(32_000L, h.dataSizeBytes)
+        // Data offset moves forward by the size of the LIST chunk (8 header + 64 payload).
+        assertEquals(36L + 8L + 64L, h.dataOffsetBytes)
+    }
+
+    @Test
+    fun `skips spurious JUNK chunk before data`() {
+        val bytes = buildWav(
+            sampleRate = 16_000, channels = 1, bitsPerSample = 16, dataBytes = 16_000,
+            extraChunkBeforeData = "JUNK" to ByteArray(28),
+        )
+        val h = WavHeader.read(ByteArrayInputStream(bytes))!!
+        assertEquals(16_000L, h.dataSizeBytes)
+    }
+
+    // ── rejection ──────────────────────────────────────────────────
+
+    @Test
+    fun `returns null on non-RIFF input`() {
+        val raw = "totally not a wav file".toByteArray()
+        assertNull(WavHeader.read(ByteArrayInputStream(raw)))
+    }
+
+    @Test
+    fun `returns null on truncated header`() {
+        val raw = "RIFF".toByteArray()
+        assertNull(WavHeader.read(ByteArrayInputStream(raw)))
+    }
+
+    @Test
+    fun `returns null when fmt chunk is missing or undersized`() {
+        // Build a WAV with a fmt chunk size of 8 (too small for PCM).
+        val buf = ByteBuffer.allocate(64).order(ByteOrder.LITTLE_ENDIAN)
+        buf.put("RIFF".toByteArray(Charsets.US_ASCII))
+        buf.putInt(20)
+        buf.put("WAVE".toByteArray(Charsets.US_ASCII))
+        buf.put("fmt ".toByteArray(Charsets.US_ASCII))
+        buf.putInt(8) // way too small
+        buf.put(ByteArray(8))
+        assertNull(WavHeader.read(ByteArrayInputStream(buf.array(), 0, buf.position())))
+    }
+
+    // ── File overload ─────────────────────────────────────────────
+
+    @Test
+    fun `read(File) matches read(InputStream) for the same payload`() {
+        val bytes = buildWav(sampleRate = 22_050, channels = 1, bitsPerSample = 16, dataBytes = 44_100)
+        val file = tmp.newFile("synthetic.wav")
+        file.writeBytes(bytes)
+        val viaStream = WavHeader.read(ByteArrayInputStream(bytes))!!
+        val viaFile = WavHeader.read(file)!!
+        assertEquals(viaStream, viaFile)
+    }
+
+    @Test
+    fun `read(File) returns null on missing file`() {
+        val nonexistent = File(tmp.root, "does_not_exist.wav")
+        assertNull(WavHeader.read(nonexistent))
+    }
+}

--- a/app/src/test/java/com/hereliesaz/liperty/voicebox/cloning/VoiceQualityTierTest.kt
+++ b/app/src/test/java/com/hereliesaz/liperty/voicebox/cloning/VoiceQualityTierTest.kt
@@ -57,7 +57,7 @@ class VoiceQualityTierTest {
     @Test
     fun `filledDots increase monotonically with rank`() {
         var prev = -1
-        for (tier in VoiceQualityTier.values().sortedBy { it.rank }) {
+        for (tier in VoiceQualityTier.entries.sortedBy { it.rank }) {
             val dots = tier.filledDots
             assert(dots >= prev) {
                 "${tier.name} has $dots dots but previous rank had $prev"
@@ -72,7 +72,7 @@ class VoiceQualityTierTest {
         // Each tier should require at least as many clips AND at
         // least as much speech as the previous tier — otherwise the
         // bands aren't monotonic in user effort and the UI can flicker.
-        val tiers = VoiceQualityTier.values().sortedBy { it.rank }
+        val tiers = VoiceQualityTier.entries.sortedBy { it.rank }
         for (i in 1 until tiers.size) {
             assert(tiers[i].minClips >= tiers[i - 1].minClips) {
                 "${tiers[i].name} requires fewer clips than ${tiers[i - 1].name}"


### PR DESCRIPTION
Follow-up to merged #93 addressing six inline review comments from gemini-code-assist and sourcery-ai. PR #93 was merged before this fix branch could land on it.

## Comments addressed

### Memory: stop loading whole audio files for metadata
- gemini #3251840927 (`VoiceViewModel.wavDurationMs` reads full file)
- gemini #3251840939 (`PocketTTSEngine.readWavFile` reads full file)
- sourcery overall: extract shared WAV utility; add size guards

Both call sites had their own ad-hoc WAV parsers and both consumed the whole file via `readBytes()` — risking OOM on long voicemails or video extracts.

Extracted a shared streaming reader (`WavHeader.kt`):
- `WavHeader.read(File|InputStream)` parses just the RIFF/WAVE header (a few hundred bytes), correctly skipping spurious LIST/JUNK/INFO chunks between fmt and data
- `PocketTTSEngine.readWavFile` now reads header via `WavHeader`, then streams the data chunk into a single `FloatArray` via a 32 KB buffer, downmixing multi-channel to mono on the fly. The full file is never resident in memory
- `VoiceViewModel.wavDurationMs` reduces to a `WavHeader.read()` call plus a length-based fallback
- Hard cap of 40 MB (~14 min @ 24 kHz mono 16-bit) on a single reference clip guards against malicious or corrupted headers declaring multi-GB data chunks

`WavHeaderTest` covers happy paths (mono/stereo, multiple sample rates), spurious-chunk skipping (LIST, JUNK), rejection paths (non-RIFF, truncated, undersized fmt).

### Enum `entries` (gemini #3251840928)

`VoiceQualityTier.compute` switches `values()` → `entries`. (The maintainer applied this directly to #93 via commit `5e1ea00` before merging; this PR adds the rationale comment and updates the test file to match.)

### Prompt index decouples from clip count (sourcery #3251841398)

Previously the displayed Harvard sentence was `HARVARD_PROMPTS[clipCount % size]`. Discarding the last clip decremented `clipCount` and jumped the user to a different prompt.

Added `promptIndex` to `CoachState`; `recomputeCoachQualityState(advancePrompt = true)` advances it on successful capture only. Discards leave it alone, so retrying lands the user back on the same sentence they just attempted.

### Clear error on success (sourcery #3251841401)

`recomputeCoachQualityState` now explicitly sets `error = null`. A transient recording failure would otherwise leave the status line stuck in error styling after the next successful clip.

### Plurals (gemini #3251840934)

Added `voice_coach_clips_captured` and `voice_coach_clip_count_inline` plural resources. `VoiceCoachScreen` routes the "Captured: N clip(s)" banner and the inline tier-card counter through `pluralStringResource` for proper grammar across locales.

(Other voice-coach strings remain hardcoded for the v0.1 cut; full i18n of the screen is tracked separately.)

## Test plan

- [ ] `./gradlew testDebugUnitTest` — verifies new `WavHeaderTest` passes, existing `PocketTTSEngineHelpersTest` / `VoiceQualityTierTest` / `VoiceViewModelTest` still pass.
- [ ] Visual smoke test of `VoiceCoachScreen`: record → discard last → confirm the prompt stays on the same Harvard sentence.
- [ ] Visual smoke test: trigger a recording failure (e.g., revoke mic permission mid-session), then re-record successfully → confirm the status line styling returns to normal (not red).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a shared streaming WAV header reader to avoid loading full audio files into memory and apply it across TTS and recording duration logic, while refining the voice coaching UX and text handling.

New Features:
- Add a reusable WavHeader utility for streaming RIFF/WAVE metadata parsing used by both PocketTTSEngine and VoiceViewModel.
- Track a separate promptIndex in CoachState to drive Harvard prompt selection independently of clip count.

Bug Fixes:
- Fix voice coach prompt jumping on clip discard by decoupling prompt selection from clip count.
- Ensure error state is cleared after successful recordings so the status line styling resets.

Enhancements:
- Update PocketTTSEngine to stream and downmix WAV audio with size caps instead of reading entire files, improving robustness against large or malformed inputs.
- Refine recomputeCoachQualityState to manage prompt advancement, clear stale errors, and centralize derived CoachState updates.
- Switch VoiceQualityTier.compute and its tests from values() to entries() for more efficient enum iteration.
- Use localized plural resources for voice coach clip count text in the UI.

Tests:
- Add WavHeaderTest to validate WAV header parsing, chunk skipping, and error handling.
- Extend VoiceViewModelTest and VoiceQualityTierTest to cover new CoachState fields, error-reset semantics, and entries()-based iteration.