### PR TITLE
Stop force-closing MainActivity when MediaPipe / ML init throws an Error

### DIFF
--- a/app/src/main/java/com/hereliesaz/liperty/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/MainActivity.kt
@@ -515,14 +515,14 @@ class MainActivity : ComponentActivity() {
                 }
             }
             coreInitialized = true
-        } catch (t: Throwable) {
-            // Throwable, not Exception: native ML libs (MediaPipe, ONNX Runtime,
-            // KenLM JNI) can fail with UnsatisfiedLinkError / NoClassDefFoundError,
-            // which aren't Exceptions. Force-closing here drops the user back to
-            // the launcher with no Toast and no log surface beyond AndroidRuntime.
-            val tag = "${t.javaClass.name}: ${t.message ?: ""}"
-            Log.e("MainActivity", "Failed to initialize components: $tag", t)
-            Toast.makeText(this, getString(R.string.common_init_error, tag), Toast.LENGTH_LONG).show()
+        } catch (e: LinkageError) {
+            // LinkageError covers UnsatisfiedLinkError / NoClassDefFoundError /
+            // ExceptionInInitializerError from native ML libs (MediaPipe, ONNX
+            // Runtime, KenLM JNI). Narrower than Throwable: VirtualMachineError
+            // (OOM / StackOverflow) shouldn't be swallowed here.
+            onInitFailure(e)
+        } catch (e: Exception) {
+            onInitFailure(e)
         }
 
         // Background initialization
@@ -560,6 +560,13 @@ class MainActivity : ComponentActivity() {
             Log.e("MainActivity", "VoiceManager construction failed — TTS/voice cloning disabled", t)
             Toast.makeText(this, getString(R.string.common_voice_unavailable), Toast.LENGTH_LONG).show()
         }
+    }
+
+    private fun onInitFailure(t: Throwable) {
+        val suffix = t.message?.let { ": $it" } ?: ""
+        val tag = "${t.javaClass.name}$suffix"
+        Log.e("MainActivity", "Failed to initialize components: $tag", t)
+        Toast.makeText(this, getString(R.string.common_init_error, tag), Toast.LENGTH_LONG).show()
     }
 
     override fun onPause() {

--- a/app/src/main/java/com/hereliesaz/liperty/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/MainActivity.kt
@@ -515,9 +515,14 @@ class MainActivity : ComponentActivity() {
                 }
             }
             coreInitialized = true
-        } catch (e: Exception) {
-            Log.e("MainActivity", "Failed to initialize components", e)
-            Toast.makeText(this, getString(R.string.common_init_error, e.message ?: ""), Toast.LENGTH_LONG).show()
+        } catch (t: Throwable) {
+            // Throwable, not Exception: native ML libs (MediaPipe, ONNX Runtime,
+            // KenLM JNI) can fail with UnsatisfiedLinkError / NoClassDefFoundError,
+            // which aren't Exceptions. Force-closing here drops the user back to
+            // the launcher with no Toast and no log surface beyond AndroidRuntime.
+            val tag = "${t.javaClass.name}: ${t.message ?: ""}"
+            Log.e("MainActivity", "Failed to initialize components: $tag", t)
+            Toast.makeText(this, getString(R.string.common_init_error, tag), Toast.LENGTH_LONG).show()
         }
 
         // Background initialization

--- a/app/src/main/java/com/hereliesaz/liperty/ml/FaceLandmarkerHelper.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/ml/FaceLandmarkerHelper.kt
@@ -62,8 +62,14 @@ class FaceLandmarkerHelper(
                 .build()
 
             faceLandmarker = FaceLandmarker.createFromOptions(context, options)
-        } catch (e: Exception) {
-            Log.e("FaceLandmarkerHelper", "Error initializing FaceLandmarker", e)
+        } catch (t: Throwable) {
+            // Throwable, not Exception: MediaPipe native-library failures
+            // surface as UnsatisfiedLinkError / ExceptionInInitializerError,
+            // which are Errors. Letting them propagate force-closes MainActivity
+            // before the outer init can show a Toast.
+            Log.e("FaceLandmarkerHelper",
+                "FaceLandmarker init failed: ${t.javaClass.name}: ${t.message}", t)
+            faceLandmarker = null
         }
     }
 

--- a/app/src/main/java/com/hereliesaz/liperty/ml/FaceLandmarkerHelper.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/ml/FaceLandmarkerHelper.kt
@@ -62,15 +62,22 @@ class FaceLandmarkerHelper(
                 .build()
 
             faceLandmarker = FaceLandmarker.createFromOptions(context, options)
-        } catch (t: Throwable) {
-            // Throwable, not Exception: MediaPipe native-library failures
-            // surface as UnsatisfiedLinkError / ExceptionInInitializerError,
-            // which are Errors. Letting them propagate force-closes MainActivity
-            // before the outer init can show a Toast.
-            Log.e("FaceLandmarkerHelper",
-                "FaceLandmarker init failed: ${t.javaClass.name}: ${t.message}", t)
-            faceLandmarker = null
+        } catch (e: LinkageError) {
+            // LinkageError covers UnsatisfiedLinkError / NoClassDefFoundError /
+            // ExceptionInInitializerError from MediaPipe's native-lib path.
+            // Narrower than Throwable: VirtualMachineError (OOM / StackOverflow)
+            // leaves the VM in an indeterminate state and shouldn't be swallowed.
+            logInitFailure(e)
+        } catch (e: Exception) {
+            logInitFailure(e)
         }
+    }
+
+    private fun logInitFailure(t: Throwable) {
+        val suffix = t.message?.let { ": $it" } ?: ""
+        Log.e("FaceLandmarkerHelper",
+            "FaceLandmarker init failed: ${t.javaClass.name}$suffix", t)
+        faceLandmarker = null
     }
 
     @Synchronized


### PR DESCRIPTION
## Summary

Triaged from a force-close report where `WindowManagerShell` logged a `CLOSE` transition with `flags = 16` (`TRANSIT_FLAG_APP_CRASHED`) for `com.hereliesaz.liperty/.MainActivity`. The partial stack trace pointed the failure at `FaceLandmarkerHelper.setupFaceLandmarker` during `MainActivity.initializeCoreComponents` → `MainActivity.onCreate`.

Both call sites already wrapped the work in `catch (e: Exception)`, yet the throwable still escaped both — which means it isn't an `Exception`, it's a `java.lang.Error`. The likely candidates at the MediaPipe init boundary are `UnsatisfiedLinkError` (`libmediapipe_tasks_vision_jni.so` missing / wrong ABI / not packaged), `NoClassDefFoundError`, or `ExceptionInInitializerError` — none of which `catch (Exception)` will catch.

## Changes

- `FaceLandmarkerHelper.setupFaceLandmarker`: widen `catch (Exception)` → `catch (Throwable)`, log `t.javaClass.name` + `t.message`, and explicitly leave `faceLandmarker = null`. The existing `detectSynchronously` already handles null and returns null, so face detection degrades cleanly instead of taking the activity down.
- `MainActivity.initializeCoreComponents`: widen the outer `catch (Exception)` → `catch (Throwable)`, surface the throwable's class name in both the logcat line and the `common_init_error` Toast so the root cause is visible without needing to grep the `AndroidRuntime` fatal dump.

The runtime catch in `FaceLandmarkerHelper.detectSynchronously` (per-frame) is intentionally left as `Exception` — different boundary, different failure mode.

## What this does NOT fix

This is a robustness / diagnostics fix, not a root-cause fix. After this change the app will still fail to initialize face detection — but it will stay alive, show a Toast naming the actual `Throwable` subclass, and dump a full stack trace under the `FaceLandmarkerHelper` tag. That tells us whether to chase a missing native lib (`setup_libs.sh` needs re-running, OpenCV 4.13.0 ABI mismatch, packaging regression) or something else.

## Test plan

- [ ] Reproduce the original force-close on the affected device and confirm the app now stays open and shows an init-error Toast instead.
- [ ] Capture the new logcat line under tag `FaceLandmarkerHelper` and use the `Throwable` class name to drive a follow-up PR on the actual root cause.
- [ ] Sanity-check on a healthy build that face detection still initializes and `coreInitialized = true` (i.e. the widened catch isn't masking a regression).

https://claude.ai/code/session_01XEV8wRKQJF7S9FpmAMtuJH

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEV8wRKQJF7S9FpmAMtuJH)_

## Summary by Sourcery

Improve app robustness when MediaPipe or other ML native libraries fail to initialize so MainActivity stays alive and surfaces clearer diagnostics instead of crashing.

Bug Fixes:
- Prevent MainActivity from crashing on native ML library linkage errors during core initialization by handling them explicitly.

Enhancements:
- Refactor initialization error handling in MainActivity into a shared helper that logs the throwable type and message and shows a more informative Toast.
- Improve FaceLandmarker initialization robustness by centralizing error logging, capturing the throwable class name in logs, and explicitly nulling the landmarker on failure so face detection degrades gracefully.