### PR TITLE
HandGestureHelper: same init catch-narrowing pattern as #108

### DIFF
--- a/app/src/main/java/com/hereliesaz/liperty/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/MainActivity.kt
@@ -563,10 +563,8 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun onInitFailure(t: Throwable) {
-        val suffix = t.message?.let { ": $it" } ?: ""
-        val tag = "${t.javaClass.name}$suffix"
-        Log.e("MainActivity", "Failed to initialize components: $tag", t)
-        Toast.makeText(this, getString(R.string.common_init_error, tag), Toast.LENGTH_LONG).show()
+        Log.e("MainActivity", "Failed to initialize components: $t", t)
+        Toast.makeText(this, getString(R.string.common_init_error, t.toString()), Toast.LENGTH_LONG).show()
     }
 
     override fun onPause() {

--- a/app/src/main/java/com/hereliesaz/liperty/ml/FaceLandmarkerHelper.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/ml/FaceLandmarkerHelper.kt
@@ -74,9 +74,7 @@ class FaceLandmarkerHelper(
     }
 
     private fun logInitFailure(t: Throwable) {
-        val suffix = t.message?.let { ": $it" } ?: ""
-        Log.e("FaceLandmarkerHelper",
-            "FaceLandmarker init failed: ${t.javaClass.name}$suffix", t)
+        Log.e("FaceLandmarkerHelper", "FaceLandmarker init failed: $t", t)
         faceLandmarker = null
     }
 

--- a/app/src/main/java/com/hereliesaz/liperty/ml/HandGestureHelper.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/ml/HandGestureHelper.kt
@@ -43,9 +43,22 @@ class HandGestureHelper(val context: Context) {
                 .build()
 
             handLandmarker = HandLandmarker.createFromOptions(context, options)
+        } catch (e: LinkageError) {
+            // LinkageError covers UnsatisfiedLinkError / NoClassDefFoundError /
+            // ExceptionInInitializerError from MediaPipe's native-lib path.
+            // Narrower than Throwable: VirtualMachineError (OOM / StackOverflow)
+            // leaves the VM in an indeterminate state and shouldn't be swallowed.
+            logInitFailure(e)
         } catch (e: Exception) {
-            Log.e("HandGestureHelper", "Error initializing HandLandmarker. Make sure hand_landmarker.task is in assets", e)
+            logInitFailure(e)
         }
+    }
+
+    private fun logInitFailure(t: Throwable) {
+        val suffix = t.message?.let { ": $it" } ?: ""
+        Log.e("HandGestureHelper",
+            "HandLandmarker init failed: ${t.javaClass.name}$suffix", t)
+        handLandmarker = null
     }
 
     fun detectSynchronously(imageBitmap: Bitmap): HandGesture? {

--- a/app/src/main/java/com/hereliesaz/liperty/ml/HandGestureHelper.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/ml/HandGestureHelper.kt
@@ -55,9 +55,7 @@ class HandGestureHelper(val context: Context) {
     }
 
     private fun logInitFailure(t: Throwable) {
-        val suffix = t.message?.let { ": $it" } ?: ""
-        Log.e("HandGestureHelper",
-            "HandLandmarker init failed: ${t.javaClass.name}$suffix", t)
+        Log.e("HandGestureHelper", "HandLandmarker init failed: $t", t)
         handLandmarker = null
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #108. Logcat from a build with #108 deployed shows the FaceLandmarkerHelper fix working — its inner `catch (LinkageError)` absorbs the MediaPipe init failure and `initializeCoreComponents` continues. But the very next constructor in `initializeCoreComponents` is `HandGestureHelper(this)`, which hits the same class of failure and *its* `catch (Exception)` block (lines 46–48 pre-change) doesn't cover `LinkageError`.

That fails over to the outer `onInitFailure` handler in `MainActivity` — so the app stays alive instead of force-closing, but every init step after `HandGestureHelper` (`OnnxModelEngine`, `VSRInference`, `KenLM`, `SyncVSR seq2seq`, `frameBuffer`, etc.) is skipped, leaving `coreInitialized = false` and the app non-functional.

Evidence (post-#108 logcat):

```
01:37:39.252 E/FaceLandmarkerHelper(19682):  at ...FaceLandmarkerHelper.setupFaceLandmarker(...:102)  # absorbed
01:37:39.252 E/FaceLandmarkerHelper(19682):  at ...FaceLandmarkerHelper.<init>(...:15)
01:40:05.455 E/MainActivity(20384):          at ...HandGestureHelper.<init>(...:28)                    # escaped to outer
01:40:05.455 E/MainActivity(20384):          at ...MainActivity.initializeCoreComponents(...:37)
```

## Changes

- `HandGestureHelper.setupHandLandmarker`: split `catch (Exception)` into `catch (LinkageError)` + `catch (Exception)`, route both to a new `logInitFailure` helper that logs `t.javaClass.name`, includes `t.message` only when non-null, and explicitly sets `handLandmarker = null`. `detectSynchronously` already null-checks, so hand-gesture detection degrades cleanly while the rest of MainActivity init continues.

Pattern is identical to what #108 did for `FaceLandmarkerHelper` — same justification, same shape.

## What this does NOT fix

Still not a root-cause fix. The underlying MediaPipe init is failing on this build/device — most likely a missing/wrong-ABI native lib from a stale `setup_libs.sh` run, or a `.task` file that wasn't shipped. After this PR the diagnostic surface will be a `HandGestureHelper`-tagged log line naming the exact `Throwable` subclass instead of a hard initialization bail.

## Test plan

- [ ] Reproduce on the affected device with this build; confirm `initializeCoreComponents` reaches `coreInitialized = true` even when both MediaPipe constructors fail.
- [ ] Capture the new `E/HandGestureHelper` log line and use the `Throwable` class name to drive a real root-cause PR on the native lib / model asset.
- [ ] Sanity-check that hand gestures still work on a healthy build.

https://claude.ai/code/session_01XEV8wRKQJF7S9FpmAMtuJH

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEV8wRKQJF7S9FpmAMtuJH)_

## Summary by Sourcery

Handle HandLandmarker initialization failures without aborting core component initialization.

Bug Fixes:
- Ensure HandGestureHelper handles MediaPipe LinkageError during HandLandmarker setup so the rest of core initialization can proceed.

Enhancements:
- Unify HandGestureHelper error handling with FaceLandmarkerHelper by centralizing HandLandmarker init failure logging and null-handling.