### PR TITLE
Fix 404s for personalization training artifact downloads

### DIFF
--- a/app/src/main/java/com/hereliesaz/liperty/setup/ModelDownloadManager.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/setup/ModelDownloadManager.kt
@@ -48,7 +48,14 @@ class ModelDownloadManager(private val context: Context) {
         val description: String,
         val expectedSizeBytes: Long = -1L,
         /** Override HF URL for non-HuggingFace sources (e.g. MediaPipe CDN). */
-        val customUrl: String? = null
+        val customUrl: String? = null,
+        /**
+         * Remote path within the HF repo. Defaults to [fileName]. Use when the
+         * local destination path differs from the file's path on the Hub —
+         * e.g. training artifacts that live at the repo root but are stored
+         * locally under a `training/` subdirectory.
+         */
+        val remotePath: String? = null
     )
 
     val models: List<ModelSpec> = listOf(
@@ -117,6 +124,7 @@ class ModelDownloadManager(private val context: Context) {
         // ~820 MB total; optional — app works fine without them.
         ModelSpec(
             fileName = "training/training_model.onnx",
+            remotePath = "training_model.onnx",
             repo = "HereLiesAz/liperty-v3-training-artifacts",
             required = false,
             description = "Personalization training model",
@@ -124,6 +132,7 @@ class ModelDownloadManager(private val context: Context) {
         ),
         ModelSpec(
             fileName = "training/eval_model.onnx",
+            remotePath = "eval_model.onnx",
             repo = "HereLiesAz/liperty-v3-training-artifacts",
             required = false,
             description = "Personalization evaluation model",
@@ -131,6 +140,7 @@ class ModelDownloadManager(private val context: Context) {
         ),
         ModelSpec(
             fileName = "training/optimizer_model.onnx",
+            remotePath = "optimizer_model.onnx",
             repo = "HereLiesAz/liperty-v3-training-artifacts",
             required = false,
             description = "Personalization optimizer",
@@ -289,6 +299,7 @@ class ModelDownloadManager(private val context: Context) {
 
     private suspend fun downloadModel(spec: ModelSpec) = withContext(Dispatchers.IO) {
         val dest = File(context.filesDir, spec.fileName)
+        dest.parentFile?.mkdirs()
 
         // Already present (from assets copy or previous download)
         if (dest.exists() && dest.length() > 1000) {
@@ -313,13 +324,13 @@ class ModelDownloadManager(private val context: Context) {
         }
 
         // Download from source (custom URL or HuggingFace)
-        val url = spec.customUrl ?: hfUrl(spec.repo, spec.fileName)
+        val url = spec.customUrl ?: hfUrl(spec.repo, spec.remotePath ?: spec.fileName)
 
         updateModelState(spec.fileName) {
             it.copy(status = Status.DOWNLOADING, progressBytes = 0)
         }
 
-        val tempFile = File(dest.parent, "${spec.fileName}.tmp")
+        val tempFile = File(dest.parentFile, "${dest.name}.tmp")
         try {
             downloadFile(url, tempFile, spec.fileName)
             if (tempFile.length() < 1000) {


### PR DESCRIPTION
## Summary

The setup screen was showing three HTTP 404s on the personalization training artifacts. The files live at the **root** of `HereLiesAz/liperty-v3-training-artifacts`, but the local destination paths under `filesDir` need the `training/` prefix that `OrtTrainer` expects. `ModelSpec.fileName` was being used for both the local path and the HF URL, so the downloader was hitting `.../resolve/main/training/training_model.onnx` (404) instead of `.../resolve/main/training_model.onnx`.

- Added an optional `remotePath` on `ModelSpec`; set it to the bare filename for the three training entries.
- Use `spec.remotePath ?: spec.fileName` when building the HF URL.
- Fixed two latent issues that bite as soon as `fileName` contains a slash: create the parent directory before writing, and base the temp file on `dest.name` (not `spec.fileName`) so the path doesn't double up to `training/training/...`.

Verified against the live HF tree — the repo contains `training_model.onnx`, `eval_model.onnx`, `optimizer_model.onnx`, `checkpoint/`, `nominal_checkpoint` at the root, no `training/` directory.

## Test plan

- [ ] Reinstall the app or clear app data so setup runs again
- [ ] Confirm the three personalization rows download successfully (or skip cleanly, since they're optional)
- [ ] Confirm files land at `filesDir/training/training_model.onnx` etc. so `OrtTrainer.areArtifactsAvailable()` continues to resolve them

https://claude.ai/code/session_015AL4Ds4CCrZb7UEyBnAjgY

---
_Generated by [Claude Code](https://claude.ai/code/session_015AL4Ds4CCrZb7UEyBnAjgY)_

## Summary by Sourcery

Fix personalization training artifact downloads by decoupling remote repository paths from local storage paths and making the download flow resilient to nested file names.

Bug Fixes:
- Ensure training ONNX artifacts are downloaded from the correct HuggingFace paths while still being stored under the local `training/` subdirectory.
- Prevent failures when `fileName` contains subdirectories by creating parent directories before writing and using a safe temporary file name based on the destination file.

Enhancements:
- Extend model specifications with an optional remote path field to support differing local and remote layouts for artifacts.