### PR TITLE
Accept legitimately tiny model artifacts (e.g. 538-byte optimizer)

### DIFF
--- a/app/src/main/java/com/hereliesaz/liperty/setup/ModelDownloadManager.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/setup/ModelDownloadManager.kt
@@ -187,13 +187,7 @@ class ModelDownloadManager(private val context: Context) {
         }
 
         // Check if all required models exist (filesDir or bundled assets)
-        val allRequiredPresent = models.filter { it.required }.all { spec ->
-            val inFilesDir = File(context.filesDir, spec.fileName)
-            val inAssets = try {
-                context.assets.open(spec.fileName).use { it.available() > 1000 }
-            } catch (_: Exception) { false }
-            (inFilesDir.exists() && inFilesDir.length() > 1000) || inAssets
-        }
+        val allRequiredPresent = models.filter { it.required }.all { isModelPresent(it) }
 
         if (allRequiredPresent) {
             prefs.edit()
@@ -211,7 +205,7 @@ class ModelDownloadManager(private val context: Context) {
     suspend fun downloadAll(skipOptional: Boolean = false) {
         // Initialize state
         val initialStates = models.associate { spec ->
-            val alreadyPresent = isModelPresent(spec.fileName)
+            val alreadyPresent = isModelPresent(spec)
             val shouldSkip = skipOptional && !spec.required
             spec.fileName to ModelDownloadState(
                 fileName = spec.fileName,
@@ -289,20 +283,32 @@ class ModelDownloadManager(private val context: Context) {
 
     // ── Internal ──────────────────────────────────────────────────────
 
-    private fun isModelPresent(fileName: String): Boolean {
-        val file = File(context.filesDir, fileName)
-        if (file.exists() && file.length() > 1000) return true
+    /**
+     * Minimum acceptable size for a downloaded file. Uses [ModelSpec.expectedSizeBytes]
+     * when set (allowing a 10% short read for variable artifacts), otherwise a small
+     * 100-byte floor to filter out HTML error pages. The optimizer ONNX is a legitimate
+     * 538-byte artifact, so a hardcoded 1 KB floor would reject it.
+     */
+    private fun minAcceptableSize(spec: ModelSpec): Long =
+        if (spec.expectedSizeBytes > 0) (spec.expectedSizeBytes * 9 / 10).coerceAtLeast(100L)
+        else 100L
+
+    private fun isModelPresent(spec: ModelSpec): Boolean {
+        val file = File(context.filesDir, spec.fileName)
+        val minSize = minAcceptableSize(spec)
+        if (file.exists() && file.length() >= minSize) return true
         return try {
-            context.assets.open(fileName).use { it.available() > 1000 }
+            context.assets.open(spec.fileName).use { it.available() >= minSize }
         } catch (_: Exception) { false }
     }
 
     private suspend fun downloadModel(spec: ModelSpec) = withContext(Dispatchers.IO) {
         val dest = File(context.filesDir, spec.fileName)
         dest.parentFile?.mkdirs()
+        val minSize = minAcceptableSize(spec)
 
         // Already present (from assets copy or previous download)
-        if (dest.exists() && dest.length() > 1000) {
+        if (dest.exists() && dest.length() >= minSize) {
             updateModelState(spec.fileName) { it.copy(status = Status.COMPLETE) }
             return@withContext
         }
@@ -310,9 +316,9 @@ class ModelDownloadManager(private val context: Context) {
         // Try assets first (dev build with setup_libs.sh)
         try {
             context.assets.open(spec.fileName).use { input ->
-                if (input.available() > 1000) {
+                if (input.available() >= minSize) {
                     dest.outputStream().use { output -> input.copyTo(output) }
-                    if (dest.length() > 1000) {
+                    if (dest.length() >= minSize) {
                         Log.i(TAG, "Copied ${spec.fileName} from assets (${dest.length()} bytes)")
                         updateModelState(spec.fileName) { it.copy(status = Status.COMPLETE) }
                         return@withContext
@@ -333,9 +339,11 @@ class ModelDownloadManager(private val context: Context) {
         val tempFile = File(dest.parentFile, "${dest.name}.tmp")
         try {
             downloadFile(url, tempFile, spec.fileName)
-            if (tempFile.length() < 1000) {
+            if (tempFile.length() < minSize) {
                 tempFile.delete()
-                throw RuntimeException("Downloaded file too small (${tempFile.length()} bytes) — likely a stub or error page")
+                throw RuntimeException(
+                    "Downloaded file too small (${tempFile.length()} bytes, expected ≥ $minSize) — likely a stub or error page"
+                )
             }
             tempFile.renameTo(dest)
             Log.i(TAG, "Downloaded ${spec.fileName} (${dest.length()} bytes)")

--- a/app/src/main/java/com/hereliesaz/liperty/setup/ModelDownloadManager.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/setup/ModelDownloadManager.kt
@@ -290,7 +290,7 @@ class ModelDownloadManager(private val context: Context) {
      * 538-byte artifact, so a hardcoded 1 KB floor would reject it.
      */
     private fun minAcceptableSize(spec: ModelSpec): Long =
-        if (spec.expectedSizeBytes > 0) (spec.expectedSizeBytes * 9 / 10).coerceAtLeast(100L)
+        if (spec.expectedSizeBytes > 0) spec.expectedSizeBytes
         else 100L
 
     private fun isModelPresent(spec: ModelSpec): Boolean {


### PR DESCRIPTION
## Summary

Follow-up to PR #110. The screenshot the user shared shows the **old** URL bug — `.../resolve/main/training/training_model.onnx` instead of `.../resolve/main/training_model.onnx` — which means the device is running an APK built before #110 (commit `c4baf96`, May 19) landed. The URL fix is already in `main`; reinstalling a fresh CI build is enough to make the first two personalization rows succeed.

But the third row (`optimizer_model.onnx`) would still fail after rebuilding, because of a second latent bug. The optimizer artifact on HF is **538 bytes** — a legitimate, valid ONNX that just stores `learning_rate` / `step` / `params` for the training session. `ModelDownloadManager` had a hardcoded 1 KB minimum and would reject anything under it as "likely a stub or error page", so the retry loop would replace one error with another.

## Changes

- New `minAcceptableSize(spec)` helper: uses 90% of `ModelSpec.expectedSizeBytes` when set (floored at 100 bytes), otherwise a flat 100-byte floor. Still filters HTML error pages, no longer rejects sub-1KB ONNX artifacts.
- `isModelPresent(fileName: String)` → `isModelPresent(spec: ModelSpec)` so it can read the per-spec expected size.
- `downloadModel` cache/asset/download checks all switch from `> 1000` to `>= minSize`.
- `isSetupComplete` collapses its inline duplicate check into `isModelPresent(it)` so the logic lives in one place.

## Verified

Pulled the optimizer file directly from HF (`curl -sL .../optimizer_model.onnx`) — 538 bytes, valid ONNX magic header, contains `learning_rate`/`step`/`params` proto fields. Training (`410_600_000L`) and eval (`410_800_000L`) artifacts are ~410 MB each and unaffected.

## Test plan

- [ ] Reinstall the app or clear app data so setup runs again
- [ ] Confirm all three personalization rows download successfully (training + eval ~820 MB total, optimizer 538 B)
- [ ] Confirm `OrtTrainer.areArtifactsAvailable()` still resolves them under `filesDir/training/`


---
_Generated by [Claude Code](https://claude.ai/code/session_011pwAAAhHpfALmchGciB3FH)_

## Summary by Sourcery

Relax model artifact size validation and centralize presence checks to support legitimately small optimizer models while still filtering out invalid downloads.

Bug Fixes:
- Allow valid model artifacts smaller than 1 KB (such as tiny optimizer ONNX files) to pass size validation instead of being incorrectly rejected as errors.

Enhancements:
- Introduce a per-model minimum acceptable size derived from expected size metadata with a small global floor to distinguish real artifacts from stub or HTML error responses.
- Unify model presence detection logic across setup and download flows by basing checks on ModelSpec rather than file name alone, and by reusing a shared helper.