### PR TITLE
Fix force-close after first-launch model download

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,9 @@
     <!-- Network access for first-launch model downloads from HuggingFace.
          After initial setup, the app operates fully offline. -->
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Read network transport (Wi-Fi vs cellular) to honor the Wi-Fi-only
+         download preference. Normal permission; granted at install. -->
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />

--- a/app/src/main/java/com/hereliesaz/liperty/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/MainActivity.kt
@@ -431,7 +431,7 @@ class MainActivity : ComponentActivity() {
                 modelName = AUTOAVSR_MODEL,
                 expectedInputLayout = VSR_INPUT_LAYOUT,
             )
-            val subwordVocab = VocabularyLoader.loadFromAssets(this, AUTOAVSR_VOCAB, blank = "<blank>")
+            val subwordVocab = VocabularyLoader.load(this, AUTOAVSR_VOCAB, blank = "<blank>")
             val kenLmScorer: KenLmScorer? = try {
                 val dst = java.io.File(filesDir, KENLM_MODEL)
                 if (!dst.exists() || dst.length() < 1000) {
@@ -532,20 +532,32 @@ class MainActivity : ComponentActivity() {
             onInitFailure(e)
         }
 
-        // Background initialization
+        // Background initialization. Each step is independently guarded: model
+        // loading can OOM or hit a native LinkageError (Throwable, not Exception),
+        // and this runs on Dispatchers.Default where an uncaught throwable would
+        // force-close the app. On any failure we drop the affected backend so the
+        // pipeline degrades (seq2seq -> CTC) instead of crashing.
         if (coreInitialized) {
             lifecycleScope.launch(Dispatchers.Default) {
-                vsrInference.initialize()
-                ssrInference?.initialize()
-                avhubertV3?.let {
-                    if (!it.initialize()) {
-                        Log.w("MainActivity", "V3 backend.initialize() returned false; falling back to V2")
+                runCatching { vsrInference.initialize() }
+                    .onFailure { Log.e("MainActivity", "CTC engine init failed", it) }
+                runCatching { ssrInference?.initialize() }
+                    .onFailure { Log.e("MainActivity", "SSR engine init failed", it) }
+                avhubertV3?.let { v3 ->
+                    val ok = runCatching { v3.initialize() }
+                        .onFailure { Log.e("MainActivity", "V3 backend init threw; falling back", it) }
+                        .getOrDefault(false)
+                    if (!ok) {
+                        Log.w("MainActivity", "V3 backend unavailable; falling back to V2")
                         avhubertV3 = null
                     }
                 }
-                syncVsrSeq2Seq?.let {
-                    if (!it.initialize()) {
-                        Log.w("MainActivity", "SyncVSR seq2seq init returned false; falling back to CTC")
+                syncVsrSeq2Seq?.let { sync2 ->
+                    val ok = runCatching { sync2.initialize() }
+                        .onFailure { Log.e("MainActivity", "SyncVSR seq2seq init threw; falling back", it) }
+                        .getOrDefault(false)
+                    if (!ok) {
+                        Log.w("MainActivity", "SyncVSR seq2seq unavailable; falling back to CTC")
                         syncVsrSeq2Seq = null
                     } else {
                         Log.i("MainActivity", "SyncVSR seq2seq backend initialized")
@@ -1039,47 +1051,61 @@ class MainActivity : ComponentActivity() {
                 }
 
                 lifecycleScope.launch(Dispatchers.Default) {
-                    val v3 = avhubertV3
-                    val sync2 = syncVsrSeq2Seq
-                    val vsrResult = when {
-                        v3 != null -> {
-                            // V3 path: AV-HuBERT seq2seq. Doesn't consume the lip
-                            // landmarks — the encoder takes only mouth ROIs.
-                            v3.runInference(framesToProcess)
+                    // Whole body guarded: this runs on Dispatchers.Default, so an
+                    // uncaught throwable here force-closes the app. A backend whose
+                    // model failed to load (encoder/decoder ONNX missing or OOM)
+                    // must degrade, not crash. The finally guarantees frames are
+                    // recycled and the inference latch is released even on failure.
+                    try {
+                        val v3 = avhubertV3
+                        val sync2 = syncVsrSeq2Seq
+                        // Route only to a backend that is actually initialized.
+                        // Non-null is NOT enough: createSyncVsr/create succeed with
+                        // just the vocab, before the (large) ONNX sessions load.
+                        val vsrResult = when {
+                            v3 != null && v3.isReady() -> {
+                                // V3 path: AV-HuBERT seq2seq. Doesn't consume the lip
+                                // landmarks — the encoder takes only mouth ROIs.
+                                v3.runInference(framesToProcess)
+                            }
+                            sync2 != null && sync2.isReady() -> {
+                                // SyncVSR seq2seq: encoder hidden states + attention
+                                // decoder greedy autoregressive loop. Same lip-ROI
+                                // input as the CTC path; landmarks unused.
+                                sync2.runInference(framesToProcess)
+                            }
+                            else -> vsrInference.runInference(framesToProcess, landmarksToProcess)
                         }
-                        sync2 != null -> {
-                            // SyncVSR seq2seq: encoder hidden states + attention
-                            // decoder greedy autoregressive loop. Same lip-ROI
-                            // input as the CTC path; landmarks unused.
-                            sync2.runInference(framesToProcess)
-                        }
-                        else -> vsrInference.runInference(framesToProcess, landmarksToProcess)
-                    }
-                    // Once inference is complete, explicitly recycle the frames
-                    for (frame in framesToProcess) {
-                        BitmapPool.recycle(frame)
-                    }
 
-                    // Viseme-aware rescoring ("Chaplin's second AI" for visual ASR):
-                    // try to swap visually-equivalent words that score higher in
-                    // the LM context. No-op when LM has no signal (Noop or
-                    // missing KenLM JNI). Runs off the UI thread; the result is
-                    // typically near-identical to input until KenLM is wired up.
-                    val rescoredText = visemeRescorer?.let {
-                        try {
-                            it.rescore(vsrResult.text)
-                        } catch (e: Exception) {
-                            Log.w("MainActivity", "visemeRescorer failed: ${e.message}")
-                            vsrResult.text
-                        }
-                    } ?: vsrResult.text
+                        // Viseme-aware rescoring ("Chaplin's second AI" for visual ASR):
+                        // try to swap visually-equivalent words that score higher in
+                        // the LM context. No-op when LM has no signal (Noop or
+                        // missing KenLM JNI). Runs off the UI thread; the result is
+                        // typically near-identical to input until KenLM is wired up.
+                        val rescoredText = visemeRescorer?.let {
+                            try {
+                                it.rescore(vsrResult.text)
+                            } catch (e: Exception) {
+                                Log.w("MainActivity", "visemeRescorer failed: ${e.message}")
+                                vsrResult.text
+                            }
+                        } ?: vsrResult.text
 
-                    withContext(Dispatchers.Main) {
-                        val rawText = rescoredText.replace("Pred: ", "").replace(Regex("\\(.*\\)"), "")
-                        Log.d("VSRPipeline", "inference done: ctc='${vsrResult.text.take(80)}' rescored='${rescoredText.take(80)}' final='$rawText' conf=${"%.2f".format(vsrResult.confidence)}")
-                        if (rawText.isNotBlank()) {
-                            transcriptionManager.appendText(rawText, vsrResult.confidence)
-                            updateTranscriptionUI()
+                        withContext(Dispatchers.Main) {
+                            val rawText = rescoredText.replace("Pred: ", "").replace(Regex("\\(.*\\)"), "")
+                            Log.d("VSRPipeline", "inference done: ctc='${vsrResult.text.take(80)}' rescored='${rescoredText.take(80)}' final='$rawText' conf=${"%.2f".format(vsrResult.confidence)}")
+                            if (rawText.isNotBlank()) {
+                                transcriptionManager.appendText(rawText, vsrResult.confidence)
+                                updateTranscriptionUI()
+                            }
+                        }
+                    } catch (t: Throwable) {
+                        Log.e("MainActivity", "Inference failed; dropping this window", t)
+                    } finally {
+                        // Explicitly recycle the frames this window owns (even on
+                        // failure) and release the latch so the next window can run.
+                        for (frame in framesToProcess) {
+                            BitmapPool.recycle(frame)
                         }
                         isInferencing = false
                     }

--- a/app/src/main/java/com/hereliesaz/liperty/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/MainActivity.kt
@@ -204,6 +204,11 @@ class MainActivity : ComponentActivity() {
         // and shipped in the APK). Cmudict-derived: 126k words across 30k
         // unique viseme sequences. ~2 MB on disk.
         const val VISEME_INDEX = "viseme_index.json"
+
+        // Strips a trailing "(...)" annotation from decoded text. Pre-compiled
+        // once: the inference loop runs on every full frame window, so building
+        // a fresh Regex each time would add needless GC churn.
+        private val PARENTHESES_REGEX = Regex("\\(.*\\)")
     }
 
     private lateinit var cameraManager: CameraManager
@@ -540,12 +545,12 @@ class MainActivity : ComponentActivity() {
         if (coreInitialized) {
             lifecycleScope.launch(Dispatchers.Default) {
                 runCatching { vsrInference.initialize() }
-                    .onFailure { Log.e("MainActivity", "CTC engine init failed", it) }
+                    .onFailure { logInitFailureOrRethrow("CTC engine init failed", it) }
                 runCatching { ssrInference?.initialize() }
-                    .onFailure { Log.e("MainActivity", "SSR engine init failed", it) }
+                    .onFailure { logInitFailureOrRethrow("SSR engine init failed", it) }
                 avhubertV3?.let { v3 ->
                     val ok = runCatching { v3.initialize() }
-                        .onFailure { Log.e("MainActivity", "V3 backend init threw; falling back", it) }
+                        .onFailure { logInitFailureOrRethrow("V3 backend init threw; falling back", it) }
                         .getOrDefault(false)
                     if (!ok) {
                         Log.w("MainActivity", "V3 backend unavailable; falling back to V2")
@@ -554,7 +559,7 @@ class MainActivity : ComponentActivity() {
                 }
                 syncVsrSeq2Seq?.let { sync2 ->
                     val ok = runCatching { sync2.initialize() }
-                        .onFailure { Log.e("MainActivity", "SyncVSR seq2seq init threw; falling back", it) }
+                        .onFailure { logInitFailureOrRethrow("SyncVSR seq2seq init threw; falling back", it) }
                         .getOrDefault(false)
                     if (!ok) {
                         Log.w("MainActivity", "SyncVSR seq2seq unavailable; falling back to CTC")
@@ -584,6 +589,14 @@ class MainActivity : ComponentActivity() {
     private fun onInitFailure(t: Throwable) {
         Log.e("MainActivity", "Failed to initialize components: $t", t)
         Toast.makeText(this, getString(R.string.common_init_error, t.toString()), Toast.LENGTH_LONG).show()
+    }
+
+    /** Logs a background-init failure, but rethrows [CancellationException] so a
+     *  cancelled lifecycleScope (activity destroyed mid-init) unwinds cleanly
+     *  instead of plowing through the remaining backend initializations. */
+    private fun logInitFailureOrRethrow(msg: String, t: Throwable) {
+        if (t is kotlinx.coroutines.CancellationException) throw t
+        Log.e("MainActivity", msg, t)
     }
 
     override fun onPause() {
@@ -1092,7 +1105,7 @@ class MainActivity : ComponentActivity() {
                         } ?: vsrResult.text
 
                         withContext(Dispatchers.Main) {
-                            val rawText = rescoredText.replace("Pred: ", "").replace(Regex("\\(.*\\)"), "")
+                            val rawText = rescoredText.replace("Pred: ", "").replace(PARENTHESES_REGEX, "")
                             Log.d("VSRPipeline", "inference done: ctc='${vsrResult.text.take(80)}' rescored='${rescoredText.take(80)}' final='$rawText' conf=${"%.2f".format(vsrResult.confidence)}")
                             if (rawText.isNotBlank()) {
                                 transcriptionManager.appendText(rawText, vsrResult.confidence)
@@ -1100,6 +1113,10 @@ class MainActivity : ComponentActivity() {
                             }
                         }
                     } catch (t: Throwable) {
+                        // Don't swallow coroutine cancellation (activity destroyed
+                        // mid-window) — rethrow so the scope unwinds cleanly and the
+                        // log isn't polluted with a false "inference failed".
+                        if (t is kotlinx.coroutines.CancellationException) throw t
                         Log.e("MainActivity", "Inference failed; dropping this window", t)
                     } finally {
                         // Explicitly recycle the frames this window owns (even on

--- a/app/src/main/java/com/hereliesaz/liperty/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/MainActivity.kt
@@ -347,6 +347,9 @@ class MainActivity : ComponentActivity() {
                             } else {
                                 requestPermissions()
                             }
+                        },
+                        onSetWifiOnly = { enabled ->
+                            lifecycleScope.launch { downloadManager.setWifiOnly(enabled) }
                         }
                     )
                 }

--- a/app/src/main/java/com/hereliesaz/liperty/ml/AvHubertDecoderSession.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/ml/AvHubertDecoderSession.kt
@@ -28,6 +28,9 @@ import java.nio.LongBuffer
  *  orchestrator can be unit-tested with deterministic fakes. */
 interface DecoderSession {
     fun initialize(): Boolean
+    /** True once the underlying ONNX session is loaded and [runStep] is safe to
+     *  call. Non-null construction does NOT imply this. */
+    fun isReady(): Boolean
     fun runStep(prevTokens: IntArray, encoderFeatures: FloatArray, encShape: LongArray): FloatArray
     val vocabSize: Int
     fun close()
@@ -80,11 +83,15 @@ class AvHubertDecoderSession(
             session = s
             Log.i(TAG, "Decoder '$modelName' loaded; vocab=$vocabSize")
             true
-        } catch (e: Exception) {
-            Log.e(TAG, "FAILED to load decoder '$modelName': ${e.message}", e)
+        } catch (t: Throwable) {
+            // Throwable (not Exception): a large ONNX session can OOM or hit a
+            // native LinkageError; neither must escape into the caller's coroutine.
+            Log.e(TAG, "FAILED to load decoder '$modelName': ${t.message}", t)
             false
         }
     }
+
+    override fun isReady(): Boolean = session != null
 
     /**
      * One autoregressive step. Returns the `(V,)` logits for the next
@@ -141,10 +148,15 @@ class AvHubertDecoderSession(
 
     private fun ensureModelOnDisk(): String {
         val dst = File(context.filesDir, modelName)
-        // openFd() throws on compressed assets (aapt2's default for .onnx).
-        // available() reports uncompressed size for both compressed and stored.
-        val assetSize = context.assets.open(modelName).use { it.available().toLong() }
-        if (dst.exists() && dst.length() == assetSize) return dst.absolutePath
+
+        // 1. Already on disk — downloaded by ModelDownloadManager (production)
+        //    or copied from assets on a previous launch.
+        if (dst.exists() && dst.length() > MIN_MODEL_BYTES) return dst.absolutePath
+
+        // 2. Bundled in assets (dev builds with setup_libs.sh) — copy to filesDir.
+        //    Throws if the asset is absent, which is the expected signal in
+        //    production builds that the model wasn't downloaded; initialize()
+        //    catches it and reports the session unready.
         context.assets.open(modelName).use { input ->
             dst.outputStream().use { output -> input.copyTo(output) }
         }
@@ -160,5 +172,7 @@ class AvHubertDecoderSession(
 
     companion object {
         private const val TAG = "AvHubertDecoderSession"
+        /** Floor distinguishing a real model from a truncated/HTML-error stub. */
+        private const val MIN_MODEL_BYTES = 1000L
     }
 }

--- a/app/src/main/java/com/hereliesaz/liperty/ml/AvHubertDecoderSession.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/ml/AvHubertDecoderSession.kt
@@ -172,7 +172,9 @@ class AvHubertDecoderSession(
 
     companion object {
         private const val TAG = "AvHubertDecoderSession"
-        /** Floor distinguishing a real model from a truncated/HTML-error stub. */
-        private const val MIN_MODEL_BYTES = 1000L
+        /** Floor distinguishing a real model from a truncated/HTML-error stub.
+         *  The decoder is ~273 MB; CDN/HTML error pages can exceed 1 KB, so a
+         *  1 MB floor is a safe lower bound well below any real model. */
+        private const val MIN_MODEL_BYTES = 1_000_000L
     }
 }

--- a/app/src/main/java/com/hereliesaz/liperty/ml/AvHubertEncoderSession.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/ml/AvHubertEncoderSession.kt
@@ -128,7 +128,9 @@ class AvHubertEncoderSession(
 
     companion object {
         private const val TAG = "AvHubertEncoderSession"
-        /** Floor distinguishing a real model from a truncated/HTML-error stub. */
-        private const val MIN_MODEL_BYTES = 1000L
+        /** Floor distinguishing a real model from a truncated/HTML-error stub.
+         *  The encoder is ~759 MB; CDN/HTML error pages can exceed 1 KB, so a
+         *  1 MB floor is a safe lower bound well below any real model. */
+        private const val MIN_MODEL_BYTES = 1_000_000L
     }
 }

--- a/app/src/main/java/com/hereliesaz/liperty/ml/AvHubertEncoderSession.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/ml/AvHubertEncoderSession.kt
@@ -24,6 +24,10 @@ import java.nio.FloatBuffer
  *  orchestrator can be unit-tested with deterministic fakes. */
 interface EncoderSession {
     fun initialize(): Boolean
+    /** True once the underlying ONNX session is loaded and [runEncode] is safe
+     *  to call. Non-null construction does NOT imply this — the model file may
+     *  be missing or have failed to load. */
+    fun isReady(): Boolean
     /** input: NCTHW `(1, 1, T, H, W)` float32 row-major;
      *  returns features `(B, T_out, C)` flattened, plus its runtime shape. */
     fun runEncode(input: FloatArray, inputShape: LongArray): Pair<FloatArray, LongArray>
@@ -59,11 +63,16 @@ class AvHubertEncoderSession(
             session = s
             Log.i(TAG, "Encoder '$modelName' loaded; input='$inputName' output='$outputName'")
             true
-        } catch (e: Exception) {
-            Log.e(TAG, "FAILED to load encoder '$modelName': ${e.message}", e)
+        } catch (t: Throwable) {
+            // Throwable (not Exception): loading a multi-hundred-MB ONNX session
+            // can OOM (VirtualMachineError) or hit a native LinkageError. Those
+            // must not escape into the caller's coroutine and force-close the app.
+            Log.e(TAG, "FAILED to load encoder '$modelName': ${t.message}", t)
             false
         }
     }
+
+    override fun isReady(): Boolean = session != null
 
     /**
      * Run the encoder.
@@ -93,10 +102,17 @@ class AvHubertEncoderSession(
 
     private fun ensureModelOnDisk(): String {
         val dst = File(context.filesDir, modelName)
-        // openFd() throws on compressed assets (aapt2's default for .onnx).
-        // available() reports uncompressed size for both compressed and stored.
-        val assetSize = context.assets.open(modelName).use { it.available().toLong() }
-        if (dst.exists() && dst.length() == assetSize) return dst.absolutePath
+
+        // 1. Already on disk — downloaded by ModelDownloadManager (production)
+        //    or copied from assets on a previous launch. This is the common
+        //    case for the large seq2seq encoder, which is fetched at first
+        //    launch, never bundled in the APK.
+        if (dst.exists() && dst.length() > MIN_MODEL_BYTES) return dst.absolutePath
+
+        // 2. Bundled in assets (dev builds with setup_libs.sh) — copy to filesDir
+        //    so ORT can mmap it. Throws if the asset is absent, which is the
+        //    expected signal in production builds that the model wasn't
+        //    downloaded; initialize() catches it and reports the session unready.
         context.assets.open(modelName).use { input ->
             dst.outputStream().use { output -> input.copyTo(output) }
         }
@@ -112,5 +128,7 @@ class AvHubertEncoderSession(
 
     companion object {
         private const val TAG = "AvHubertEncoderSession"
+        /** Floor distinguishing a real model from a truncated/HTML-error stub. */
+        private const val MIN_MODEL_BYTES = 1000L
     }
 }

--- a/app/src/main/java/com/hereliesaz/liperty/ml/AvHubertSeq2SeqInference.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/ml/AvHubertSeq2SeqInference.kt
@@ -65,6 +65,12 @@ class AvHubertSeq2SeqInference(
         return a && b
     }
 
+    /** True only when both ONNX sessions are loaded and [runInference] is safe.
+     *  The caller must check this before routing frames here — a constructed but
+     *  uninitialized backend (e.g. its model file was never downloaded) would
+     *  otherwise throw inside [runInference] and crash the inference coroutine. */
+    fun isReady(): Boolean = encoder.isReady() && decoder.isReady()
+
     /**
      * Run V3 inference on the supplied frames. Takes the LAST [numFrames]
      * frames if more are provided; pads with zeros if fewer.
@@ -154,7 +160,7 @@ class AvHubertSeq2SeqInference(
         ): AvHubertSeq2SeqInference {
             val enc = AvHubertEncoderSession(context, encoderAsset)
             val dec = AvHubertDecoderSession(context, decoderAsset)
-            val dictText = context.assets.open(dictAsset).bufferedReader().use { it.readText() }
+            val dictText = VocabularyLoader.readTextPreferringFiles(context, dictAsset)
             val dict = VocabularyLoader.parseTokenList(dictText)
             return AvHubertSeq2SeqInference(enc, dec, dict)
         }
@@ -184,7 +190,7 @@ class AvHubertSeq2SeqInference(
         ): AvHubertSeq2SeqInference {
             val enc = AvHubertEncoderSession(context, encoderAsset)
             val dec = AvHubertDecoderSession(context, decoderAsset)
-            val vocabText = context.assets.open(vocabAsset).bufferedReader().use { it.readText() }
+            val vocabText = VocabularyLoader.readTextPreferringFiles(context, vocabAsset)
             val vocab = VocabularyLoader.parseTokenList(vocabText)
             // espnet convention: <eos> doubles as <sos>. SyncVSR's unigram
             // dump ends with <eos> at index (vocab.size - 1).

--- a/app/src/main/java/com/hereliesaz/liperty/ml/OnnxModelEngine.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/ml/OnnxModelEngine.kt
@@ -62,8 +62,11 @@ class OnnxModelEngine(
                     "output shape=${outputShape.contentToString()}"
             )
             true
-        } catch (e: Exception) {
-            Log.e("OnnxModelEngine", "FAILED to load model '$modelName': ${e.message}", e)
+        } catch (t: Throwable) {
+            // Throwable (not Exception): loading a large ONNX session can OOM
+            // (VirtualMachineError) or hit a native LinkageError. These must not
+            // escape into the background-init coroutine and force-close the app.
+            Log.e("OnnxModelEngine", "FAILED to load model '$modelName': ${t.message}", t)
             false
         }
     }

--- a/app/src/main/java/com/hereliesaz/liperty/ml/VocabularyLoader.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/ml/VocabularyLoader.kt
@@ -1,6 +1,7 @@
 package com.hereliesaz.liperty.ml
 
 import android.content.Context
+import java.io.File
 
 /**
  * Parses Auto-AVSR / ESPnet-style token list files (e.g. `unigram5000_units.txt`)
@@ -23,6 +24,27 @@ object VocabularyLoader {
     fun loadFromAssets(context: Context, assetName: String, blank: String = "_"): List<String> {
         val text = context.assets.open(assetName).bufferedReader().use { it.readText() }
         return withBlankAtZero(parseTokenList(text), blank)
+    }
+
+    /**
+     * Reads `name` preferring [Context.getFilesDir] (where [ModelDownloadManager]
+     * places files at first launch) and falling back to bundled assets (dev
+     * builds). Returns the parsed token list with a blank prepended at index 0.
+     *
+     * Use this instead of [loadFromAssets] for vocabularies that are downloaded
+     * rather than bundled — the assets-only path can't see a downloaded file.
+     */
+    fun load(context: Context, name: String, blank: String = "_"): List<String> =
+        withBlankAtZero(parseTokenList(readTextPreferringFiles(context, name)), blank)
+
+    /**
+     * Raw text read that prefers a downloaded file in [Context.getFilesDir] over
+     * a bundled asset. Throws if the resource is in neither location.
+     */
+    fun readTextPreferringFiles(context: Context, name: String): String {
+        val file = File(context.filesDir, name)
+        if (file.exists() && file.length() > 0) return file.readText()
+        return context.assets.open(name).bufferedReader().use { it.readText() }
     }
 
     /**

--- a/app/src/main/java/com/hereliesaz/liperty/setup/ModelDownloadManager.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/setup/ModelDownloadManager.kt
@@ -28,7 +28,7 @@ class ModelDownloadManager(private val context: Context) {
         private const val KEY_SETUP_VERSION = "setup_version"
 
         /** Bump when the required model manifest changes (forces re-check). */
-        private const val CURRENT_SETUP_VERSION = 2
+        private const val CURRENT_SETUP_VERSION = 3
 
         /** HuggingFace CDN pattern — follows redirect to CF/S3 edge. */
         private const val HF_BASE = "https://huggingface.co"
@@ -85,13 +85,39 @@ class ModelDownloadManager(private val context: Context) {
             expectedSizeBytes = 7_900_000L,
             customUrl = "https://storage.googleapis.com/mediapipe-models/hand_landmarker/hand_landmarker/float16/1/hand_landmarker.task"
         ),
-        // Production VSR model
+        // Production VSR model — CTC fallback path (graceful degradation when the
+        // larger seq2seq encoder/decoder can't load, e.g. OOM on low-RAM devices).
         ModelSpec(
             fileName = "syncvsr_lrs3_visual_ctc_fp16.onnx",
             repo = "HereLiesAz/liperty-syncvsr-onnx",
             required = true,
             description = "Visual Speech Recognition model",
             expectedSizeBytes = 370_000_000L
+        ),
+        // SyncVSR seq2seq backend (active production path: VSR_BACKEND ==
+        // BACKEND_SYNC_VSR, SYNCVSR_USE_SEQ2SEQ == true). The vocab is tiny but
+        // required by BOTH the seq2seq and CTC paths; the encoder/decoder are
+        // large and never bundled in the APK, so they MUST be downloaded here.
+        ModelSpec(
+            fileName = "syncvsr_unigram_units.txt",
+            repo = "HereLiesAz/liperty-syncvsr-onnx",
+            required = true,
+            description = "Speech recognition vocabulary",
+            expectedSizeBytes = 65_000L
+        ),
+        ModelSpec(
+            fileName = "syncvsr_lrs3_encoder.onnx",
+            repo = "HereLiesAz/liperty-syncvsr-onnx",
+            required = true,
+            description = "Speech recognition encoder (high accuracy)",
+            expectedSizeBytes = 759_000_000L
+        ),
+        ModelSpec(
+            fileName = "syncvsr_lrs3_decoder.onnx",
+            repo = "HereLiesAz/liperty-syncvsr-onnx",
+            required = true,
+            description = "Speech recognition decoder (high accuracy)",
+            expectedSizeBytes = 273_000_000L
         ),
         ModelSpec(
             fileName = "librispeech_3gram.bin",

--- a/app/src/main/java/com/hereliesaz/liperty/setup/ModelDownloadManager.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/setup/ModelDownloadManager.kt
@@ -1,6 +1,8 @@
 package com.hereliesaz.liperty.setup
 
 import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -26,6 +28,10 @@ class ModelDownloadManager(private val context: Context) {
         private const val PREFS_NAME = "ModelDownloadPrefs"
         private const val KEY_SETUP_COMPLETE = "setup_complete"
         private const val KEY_SETUP_VERSION = "setup_version"
+        /** When true (default), network downloads only run on Wi-Fi/Ethernet —
+         *  not cellular. Saves battery (cellular radio is power-hungry) and
+         *  avoids large transfers over metered data. */
+        private const val KEY_WIFI_ONLY = "download_wifi_only"
 
         /** Bump when the required model manifest changes (forces re-check). */
         private const val CURRENT_SETUP_VERSION = 3
@@ -188,7 +194,12 @@ class ModelDownloadManager(private val context: Context) {
     data class DownloadState(
         val modelStates: Map<String, ModelDownloadState> = emptyMap(),
         val isComplete: Boolean = false,
-        val error: String? = null
+        val error: String? = null,
+        /** Current Wi-Fi-only preference, mirrored here so the UI is state-driven. */
+        val wifiOnly: Boolean = true,
+        /** True when a download is held back because Wi-Fi-only is on and the
+         *  device is on cellular. The UI shows a "waiting for Wi-Fi" prompt. */
+        val blockedOnNetwork: Boolean = false
     )
 
     data class ModelDownloadState(
@@ -204,10 +215,45 @@ class ModelDownloadManager(private val context: Context) {
             get() = if (totalBytes > 0) progressBytes.toFloat() / totalBytes else 0f
     }
 
-    enum class Status { PENDING, DOWNLOADING, COMPLETE, SKIPPED, ERROR }
+    enum class Status { PENDING, DOWNLOADING, COMPLETE, SKIPPED, ERROR, WAITING_WIFI }
 
-    private val _state = MutableStateFlow(DownloadState())
+    private val _state = MutableStateFlow(DownloadState(wifiOnly = isWifiOnly()))
     val state: StateFlow<DownloadState> = _state.asStateFlow()
+
+    private fun prefs() = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    /** Whether downloads are restricted to Wi-Fi/Ethernet. Defaults to true. */
+    fun isWifiOnly(): Boolean = prefs().getBoolean(KEY_WIFI_ONLY, true)
+
+    /**
+     * Persists the Wi-Fi-only preference. When the user switches to allow
+     * cellular while a download is currently blocked, resume it immediately.
+     */
+    suspend fun setWifiOnly(enabled: Boolean) {
+        prefs().edit().putBoolean(KEY_WIFI_ONLY, enabled).apply()
+        val wasBlocked = _state.value.blockedOnNetwork
+        _state.value = _state.value.copy(wifiOnly = enabled)
+        if (!enabled && wasBlocked) {
+            // Cellular now permitted and we were waiting — pick up where we left off.
+            downloadAll(skipOptional = false)
+        }
+    }
+
+    /**
+     * True if the active network satisfies the current download policy. With
+     * Wi-Fi-only on, only WIFI/ETHERNET transports qualify (a metered Wi-Fi
+     * hotspot still counts as Wi-Fi by transport, which matches the user's
+     * "Wi-Fi only" intent of avoiding the cellular radio). With it off, any
+     * validated network is fine.
+     */
+    private fun networkAllowsDownload(): Boolean {
+        if (!isWifiOnly()) return true
+        val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+            ?: return false
+        val caps = cm.getNetworkCapabilities(cm.activeNetwork) ?: return false
+        return caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) ||
+            caps.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)
+    }
 
     /** True if all required models are present on disk. */
     fun isSetupComplete(): Boolean {
@@ -238,7 +284,7 @@ class ModelDownloadManager(private val context: Context) {
      * Call from a coroutine scope (e.g., viewModelScope).
      */
     suspend fun downloadAll(skipOptional: Boolean = false) {
-        // Initialize state
+        // Initialize state (preserve the Wi-Fi-only preference; clear stale block)
         val initialStates = models.associate { spec ->
             val alreadyPresent = isModelPresent(spec)
             val shouldSkip = skipOptional && !spec.required
@@ -253,7 +299,7 @@ class ModelDownloadManager(private val context: Context) {
                 }
             )
         }
-        _state.value = DownloadState(modelStates = initialStates)
+        _state.value = DownloadState(modelStates = initialStates, wifiOnly = isWifiOnly())
 
         // Download each model that isn't already present
         for (spec in models) {
@@ -262,6 +308,14 @@ class ModelDownloadManager(private val context: Context) {
 
             try {
                 downloadModel(spec)
+            } catch (e: NetworkBlockedException) {
+                // Wi-Fi-only is on and we're on cellular. Stop here (the model is
+                // already marked WAITING_WIFI) and let the UI prompt the user.
+                _state.value = _state.value.copy(
+                    blockedOnNetwork = true,
+                    error = "Waiting for Wi-Fi. Connect to Wi-Fi, or allow cellular to continue."
+                )
+                return
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to download ${spec.fileName}", e)
                 updateModelState(spec.fileName) {
@@ -308,6 +362,12 @@ class ModelDownloadManager(private val context: Context) {
                     .apply()
                 _state.value = _state.value.copy(isComplete = true, error = null)
             }
+        } catch (e: NetworkBlockedException) {
+            // Already marked WAITING_WIFI by downloadModel; surface the prompt.
+            _state.value = _state.value.copy(
+                blockedOnNetwork = true,
+                error = "Waiting for Wi-Fi. Connect to Wi-Fi, or allow cellular to continue."
+            )
         } catch (e: Exception) {
             Log.e(TAG, "Retry failed for $fileName", e)
             updateModelState(fileName) {
@@ -315,6 +375,10 @@ class ModelDownloadManager(private val context: Context) {
             }
         }
     }
+
+    /** Thrown by [downloadModel] when a network transfer is needed but the
+     *  Wi-Fi-only policy disallows the current (cellular) connection. */
+    private class NetworkBlockedException : Exception()
 
     // ── Internal ──────────────────────────────────────────────────────
 
@@ -350,6 +414,13 @@ class ModelDownloadManager(private val context: Context) {
             }
         } catch (_: Exception) {
             // Asset not bundled — expected for production builds
+        }
+
+        // A network transfer is required from here (not already on disk or in
+        // assets). Honor the Wi-Fi-only policy before touching the radio.
+        if (!networkAllowsDownload()) {
+            updateModelState(spec.fileName) { it.copy(status = Status.WAITING_WIFI) }
+            throw NetworkBlockedException()
         }
 
         // Download from source (custom URL or HuggingFace)

--- a/app/src/main/java/com/hereliesaz/liperty/ui/SetupScreen.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/ui/SetupScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -43,7 +44,8 @@ fun SetupScreen(
     onStartDownload: () -> Unit,
     onRetryModel: (String) -> Unit,
     onSkipOptional: () -> Unit,
-    onContinue: () -> Unit
+    onContinue: () -> Unit,
+    onSetWifiOnly: (Boolean) -> Unit
 ) {
     val hasStarted = downloadState.modelStates.any {
         it.value.status != ModelDownloadManager.Status.PENDING
@@ -84,7 +86,34 @@ fun SetupScreen(
                 modifier = Modifier.padding(horizontal = 16.dp)
             )
 
-            Spacer(Modifier.height(24.dp))
+            Spacer(Modifier.height(16.dp))
+
+            // Wi-Fi-only preference. Default on: keeps large downloads off the
+            // power-hungry cellular radio and off metered data.
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "Wi-Fi only",
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium
+                    )
+                    Text(
+                        text = "Recommended — avoids cellular data and saves battery",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Switch(
+                    checked = downloadState.wifiOnly,
+                    onCheckedChange = onSetWifiOnly
+                )
+            }
+
+            Spacer(Modifier.height(8.dp))
 
             // Overall progress
             if (hasStarted) {
@@ -161,6 +190,27 @@ fun SetupScreen(
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     Text("Continue to App")
+                }
+            } else if (downloadState.blockedOnNetwork) {
+                Text(
+                    text = "Waiting for Wi-Fi. Connect to a Wi-Fi network to continue, " +
+                        "or download over cellular (uses mobile data).",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(8.dp)
+                )
+                Button(
+                    onClick = onStartDownload,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Retry on Wi-Fi")
+                }
+                Spacer(Modifier.height(8.dp))
+                OutlinedButton(
+                    onClick = { onSetWifiOnly(false) },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Download over cellular")
                 }
             } else if (downloadState.error != null) {
                 Text(
@@ -243,6 +293,12 @@ private fun ModelDownloadCard(
                     ModelDownloadManager.Status.SKIPPED ->
                         Text(
                             "Skipped",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.outline
+                        )
+                    ModelDownloadManager.Status.WAITING_WIFI ->
+                        Text(
+                            "Waiting for Wi-Fi",
                             style = MaterialTheme.typography.labelSmall,
                             color = MaterialTheme.colorScheme.outline
                         )

--- a/app/src/test/java/com/hereliesaz/liperty/ml/AvHubertSeq2SeqInferenceTest.kt
+++ b/app/src/test/java/com/hereliesaz/liperty/ml/AvHubertSeq2SeqInferenceTest.kt
@@ -35,10 +35,13 @@ class AvHubertSeq2SeqInferenceTest {
     private class FakeEncoder(
         /** What runEncode returns, regardless of input. */
         private val out: Pair<FloatArray, LongArray>,
+        /** Simulates whether the underlying ONNX session loaded. */
+        var ready: Boolean = true,
     ) : EncoderSession {
         var encodeCalls = 0
         var lastInputShape: LongArray? = null
-        override fun initialize(): Boolean = true
+        override fun initialize(): Boolean = ready
+        override fun isReady(): Boolean = ready
         override fun runEncode(input: FloatArray, inputShape: LongArray): Pair<FloatArray, LongArray> {
             encodeCalls++
             lastInputShape = inputShape
@@ -52,10 +55,13 @@ class AvHubertSeq2SeqInferenceTest {
          *  the next token. After the plan runs out, emits the eos token (2). */
         private val plan: IntArray,
         override val vocabSize: Int = 6,
+        /** Simulates whether the underlying ONNX session loaded. */
+        var ready: Boolean = true,
     ) : DecoderSession {
         var stepCalls = 0
         val prevTokensSeen = ArrayList<IntArray>()
-        override fun initialize(): Boolean = true
+        override fun initialize(): Boolean = ready
+        override fun isReady(): Boolean = ready
         override fun runStep(
             prevTokens: IntArray,
             encoderFeatures: FloatArray,
@@ -158,6 +164,26 @@ class AvHubertSeq2SeqInferenceTest {
         val seen = fakeEnc.lastInputShape!!
         assertEquals(5, seen.size)
         assertEquals(longArrayOf(1L, 16L, 1L, 88L, 88L).toList(), seen.toList())
+    }
+
+    @Test
+    fun isReadyRequiresBothSessionsLoaded() {
+        val featShape = longArrayOf(1L, 2L, 8L)
+        val enc = FakeEncoder(FloatArray(16) to featShape)
+        val dec = FakeDecoder(plan = intArrayOf(2))
+        val orch = AvHubertSeq2SeqInference(encoder = enc, decoder = dec, dict = dict)
+
+        // Both ready
+        assertTrue(orch.isReady())
+
+        // Encoder failed to load -> not ready (routing must skip this backend)
+        enc.ready = false
+        assertTrue("encoder unready => backend unready", !orch.isReady())
+
+        // Decoder failed to load -> not ready
+        enc.ready = true
+        dec.ready = false
+        assertTrue("decoder unready => backend unready", !orch.isReady())
     }
 
     @Test

--- a/app/src/test/java/com/hereliesaz/liperty/ml/TrainingDataPreparerTest.kt
+++ b/app/src/test/java/com/hereliesaz/liperty/ml/TrainingDataPreparerTest.kt
@@ -17,6 +17,8 @@ class TrainingDataPreparerTest {
     private class FakeEncoder : EncoderSession {
         override fun initialize() = true
 
+        override fun isReady() = true
+
         override fun runEncode(
             input: FloatArray,
             inputShape: LongArray,

--- a/app/src/test/java/com/hereliesaz/liperty/ml/VocabularyLoaderContextTest.kt
+++ b/app/src/test/java/com/hereliesaz/liperty/ml/VocabularyLoaderContextTest.kt
@@ -1,0 +1,60 @@
+package com.hereliesaz.liperty.ml
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.io.File
+
+/**
+ * Tests the filesDir-aware loaders added to fix the post-download crash:
+ * vocab files are DOWNLOADED into [Context.getFilesDir], so the old
+ * assets-only [VocabularyLoader.loadFromAssets] couldn't see them. [load] and
+ * [readTextPreferringFiles] must prefer a downloaded file and fall back to a
+ * bundled asset.
+ *
+ * AndroidJUnit4 + sdk=34 per the project's Robolectric/targetSdk=37 workaround.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class VocabularyLoaderContextTest {
+
+    private fun context(): Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun loadPrefersDownloadedFileInFilesDir() {
+        val ctx = context()
+        val name = "test_unigram_units.txt"
+        File(ctx.filesDir, name).writeText("▁hi 1\n▁there 2\n")
+
+        val vocab = VocabularyLoader.load(ctx, name, blank = "<blank>")
+
+        // Blank prepended at index 0, then tokens in file order.
+        assertEquals(listOf("<blank>", "▁hi", "▁there"), vocab)
+    }
+
+    @Test
+    fun readTextPrefersFilesDirOverAsset() {
+        val ctx = context()
+        // homophones.json IS a bundled asset; a filesDir file of the same name
+        // must win.
+        val name = "homophones.json"
+        File(ctx.filesDir, name).writeText("FROM_FILES_DIR")
+
+        assertEquals("FROM_FILES_DIR", VocabularyLoader.readTextPreferringFiles(ctx, name))
+    }
+
+    @Test
+    fun readTextFallsBackToAssetWhenNoFile() {
+        val ctx = context()
+        // No filesDir copy of this bundled asset -> read from assets.
+        File(ctx.filesDir, "homophones.json").delete()
+
+        val text = VocabularyLoader.readTextPreferringFiles(ctx, "homophones.json")
+        assertTrue("asset content should be non-empty JSON", text.contains("{"))
+    }
+}

--- a/app/src/test/java/com/hereliesaz/liperty/setup/ModelDownloadManagerTest.kt
+++ b/app/src/test/java/com/hereliesaz/liperty/setup/ModelDownloadManagerTest.kt
@@ -27,6 +27,9 @@ class ModelDownloadManagerTest {
     @Before
     fun setUp() {
         val context = ApplicationProvider.getApplicationContext<Context>()
+        // Clear shared state so tests don't leak setup_complete/version across runs.
+        context.getSharedPreferences("ModelDownloadPrefs", Context.MODE_PRIVATE)
+            .edit().clear().apply()
         manager = ModelDownloadManager(context)
     }
 
@@ -66,7 +69,6 @@ class ModelDownloadManagerTest {
     @Test
     fun freshInstallIsNotSetupComplete() {
         // No models on disk -> setup is not complete (the setup screen must show).
-        clearPrefs()
         assertFalse(manager.isSetupComplete())
     }
 
@@ -88,11 +90,5 @@ class ModelDownloadManagerTest {
             "stale setup_complete at an older version must not short-circuit",
             manager.isSetupComplete()
         )
-    }
-
-    private fun clearPrefs() {
-        ApplicationProvider.getApplicationContext<Context>()
-            .getSharedPreferences("ModelDownloadPrefs", Context.MODE_PRIVATE)
-            .edit().clear().apply()
     }
 }

--- a/app/src/test/java/com/hereliesaz/liperty/setup/ModelDownloadManagerTest.kt
+++ b/app/src/test/java/com/hereliesaz/liperty/setup/ModelDownloadManagerTest.kt
@@ -1,0 +1,98 @@
+package com.hereliesaz.liperty.setup
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Guards the first-launch download manifest against the regression that caused
+ * the post-download force-close: the active SyncVSR seq2seq backend needs the
+ * vocab + encoder + decoder, but they were missing from [ModelDownloadManager.models],
+ * so they were never downloaded and the pipeline crashed on the unloaded sessions.
+ *
+ * Uses AndroidJUnit4 + sdk=34 per the project's Robolectric/targetSdk=37 workaround.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class ModelDownloadManagerTest {
+
+    private lateinit var manager: ModelDownloadManager
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        manager = ModelDownloadManager(context)
+    }
+
+    @Test
+    fun manifestIncludesSeq2SeqModelsAsRequired() {
+        val required = manager.models.filter { it.required }.map { it.fileName }.toSet()
+
+        // The active backend (VSR_BACKEND == BACKEND_SYNC_VSR, SYNCVSR_USE_SEQ2SEQ)
+        // cannot assemble without these three. They must be fetched at first
+        // launch — none of them is bundled in the production APK.
+        assertTrue("vocab must be required", "syncvsr_unigram_units.txt" in required)
+        assertTrue("seq2seq encoder must be required", "syncvsr_lrs3_encoder.onnx" in required)
+        assertTrue("seq2seq decoder must be required", "syncvsr_lrs3_decoder.onnx" in required)
+
+        // The CTC fallback model and face detector remain required too.
+        assertTrue("CTC model must be required", "syncvsr_lrs3_visual_ctc_fp16.onnx" in required)
+        assertTrue("face landmarker must be required", "face_landmarker.task" in required)
+    }
+
+    @Test
+    fun seq2SeqModelSpecsPointAtSyncVsrRepo() {
+        val byName = manager.models.associateBy { it.fileName }
+        for (name in listOf(
+            "syncvsr_unigram_units.txt",
+            "syncvsr_lrs3_encoder.onnx",
+            "syncvsr_lrs3_decoder.onnx",
+        )) {
+            val spec = byName[name]
+            assertTrue("$name present in manifest", spec != null)
+            org.junit.Assert.assertEquals(
+                "$name must be fetched from the syncvsr repo",
+                "HereLiesAz/liperty-syncvsr-onnx", spec!!.repo
+            )
+        }
+    }
+
+    @Test
+    fun freshInstallIsNotSetupComplete() {
+        // No models on disk -> setup is not complete (the setup screen must show).
+        clearPrefs()
+        assertFalse(manager.isSetupComplete())
+    }
+
+    @Test
+    fun manifestVersionBumpForcesRecheckForOldInstalls() {
+        // Simulate a pre-existing install that completed setup under an older
+        // manifest version (before the seq2seq models were required). The
+        // version bump must invalidate the stale setup_complete flag so the
+        // new required models get pulled. With no models on disk, the result
+        // is "not complete".
+        val prefs = ApplicationProvider.getApplicationContext<Context>()
+            .getSharedPreferences("ModelDownloadPrefs", Context.MODE_PRIVATE)
+        prefs.edit()
+            .putBoolean("setup_complete", true)
+            .putInt("setup_version", 2)
+            .apply()
+
+        assertFalse(
+            "stale setup_complete at an older version must not short-circuit",
+            manager.isSetupComplete()
+        )
+    }
+
+    private fun clearPrefs() {
+        ApplicationProvider.getApplicationContext<Context>()
+            .getSharedPreferences("ModelDownloadPrefs", Context.MODE_PRIVATE)
+            .edit().clear().apply()
+    }
+}

--- a/app/src/test/java/com/hereliesaz/liperty/setup/ModelDownloadManagerTest.kt
+++ b/app/src/test/java/com/hereliesaz/liperty/setup/ModelDownloadManagerTest.kt
@@ -1,14 +1,20 @@
 package com.hereliesaz.liperty.setup
 
 import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowNetworkCapabilities
 
 /**
  * Guards the first-launch download manifest against the regression that caused
@@ -90,5 +96,45 @@ class ModelDownloadManagerTest {
             "stale setup_complete at an older version must not short-circuit",
             manager.isSetupComplete()
         )
+    }
+
+    @Test
+    fun wifiOnlyDefaultsToTrue() {
+        assertTrue("Wi-Fi-only must default on to protect battery/data", manager.isWifiOnly())
+    }
+
+    @Test
+    fun setWifiOnlyPersists() = runBlocking {
+        manager.setWifiOnly(false)
+        assertFalse(manager.isWifiOnly())
+        manager.setWifiOnly(true)
+        assertTrue(manager.isWifiOnly())
+    }
+
+    @Test
+    fun cellularWithWifiOnlyBlocksDownload() = runBlocking {
+        // Active network is cellular; Wi-Fi-only is on (default).
+        setActiveTransport(NetworkCapabilities.TRANSPORT_CELLULAR)
+
+        manager.downloadAll(skipOptional = false)
+
+        assertTrue(
+            "cellular + Wi-Fi-only must block, not download",
+            manager.state.value.blockedOnNetwork
+        )
+        // The first required model should be parked waiting for Wi-Fi, never ERROR.
+        assertEquals(
+            ModelDownloadManager.Status.WAITING_WIFI,
+            manager.state.value.modelStates["face_landmarker.task"]?.status
+        )
+    }
+
+    /** Points the active network's capabilities at a single transport type. */
+    private fun setActiveTransport(transport: Int) {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        val cm = ctx.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val caps = ShadowNetworkCapabilities.newInstance()
+        shadowOf(caps).addTransportType(transport)
+        shadowOf(cm).setNetworkCapabilities(cm.activeNetwork, caps)
     }
 }


### PR DESCRIPTION
## Summary

Fixes the crash where the app force-closes after downloading models on first launch and pressing **Continue**.

**Root cause (verified):** the active backend is SyncVSR seq2seq (`MainActivity.kt:85,175`), but the download manifest only fetched the 370 MB CTC model + face landmarker. The seq2seq vocab/encoder/decoder were never downloaded, the loaders only looked in `assets` (downloads land in `filesDir`), and inference routed to `syncVsrSeq2Seq` whenever it was *non-null* — which happens as soon as the tiny vocab loads, before the large ONNX sessions do. `runEncode` then hit `error("...not initialized")` inside an unguarded `Dispatchers.Default` coroutine → uncaught throwable → force close. Loading a ~1 GB model can also throw `OutOfMemoryError`/`LinkageError`, which the `catch (Exception)` blocks did not cover.

## Changes

- **Ship the seq2seq models.** Added `syncvsr_unigram_units.txt` (required), `syncvsr_lrs3_encoder.onnx`, and `syncvsr_lrs3_decoder.onnx` to `ModelDownloadManager.models`, and bumped `CURRENT_SETUP_VERSION` (2 → 3) so existing installs re-run setup and pull the new required files.
- **Find downloaded files.** `VocabularyLoader.load`/`readTextPreferringFiles` and the AvHubert encoder/decoder `ensureModelOnDisk` now prefer `filesDir` before `assets`, mirroring `OnnxModelEngine`.
- **Stop the crash (defense in depth).** Backend routing is gated on a new `isReady()` (sessions actually loaded) instead of non-null; the background-init and inference coroutines are wrapped so an OOM/LinkageError degrades to the CTC fallback instead of force-closing; session `initialize()` now catches `Throwable`, not just `Exception`. The inference coroutine recycles frames and releases the `isInferencing` latch in a `finally`.
- **Tests.** New `ModelDownloadManagerTest` (manifest regression guard + version-bump re-check), `VocabularyLoaderContextTest` (filesDir-first loading), and `isReady()` gating cases in `AvHubertSeq2SeqInferenceTest`.

## Notes

- Per the chosen direction, seq2seq is fully enabled — this makes the first-launch download ~1 GB larger and increases runtime memory. The hardening makes an OOM non-fatal (falls back to CTC). A possible follow-up is to lazy-load the CTC engine only when seq2seq is the active backend, to avoid ~370 MB of redundant resident ONNX.

## Test plan

- [ ] CI: `setup_libs.sh` + `./gradlew testDebugUnitTest` green (no Android SDK in the dev container, so unit tests/build were not run locally).
- [ ] CI: `./gradlew assembleRelease` compiles.
- [ ] Device, golden path: clear app data → launch → download all required (now incl. encoder/decoder/vocab) → **Continue** → no force close; camera + seq2seq transcription work.
- [ ] Device, edge: delete the encoder from `filesDir` before Continue → app falls back to CTC / degrades, does not crash (validates readiness gate + coroutine guards).

https://claude.ai/code/session_01E63x5prFuKex3V1iJapNwk

---
_Generated by [Claude Code](https://claude.ai/code/session_01E63x5prFuKex3V1iJapNwk)_