### PR TITLE
A4: export self-contained SyncVSR FP32 CTC ONNX

### DIFF
--- a/tools/_build_export_syncvsr_notebook.py
+++ b/tools/_build_export_syncvsr_notebook.py
@@ -402,7 +402,29 @@ torch.onnx.export(
 print(f"Exported: {ONNX_PATH} ({ONNX_PATH.stat().st_size/1e6:.1f} MB)")
 """))
 
-cells.append(md("## 9. Parity check: ONNX vs PyTorch"))
+cells.append(md("""\
+## 8b. Consolidate external weights into a single self-contained file
+
+`torch.onnx.export` can spill tensors to a sibling `<model>.onnx.data`
+file. If that file is dropped at upload time (the `allow_patterns` below
+only matched `*.onnx`), the model on HF becomes an unusable ~2 MB proto
+with dangling external-data references — the bug that broke the FP32
+upload (see `docs/EVAL_RESULTS_2026-05-13.md`). Re-save as a single file
+so the artifact is self-contained (~370 MB < the 2 GB protobuf limit)."""))
+cells.append(code("""\
+import onnx
+
+_m = onnx.load(str(ONNX_PATH), load_external_data=True)
+onnx.save_model(_m, str(ONNX_PATH), save_as_external_data=False)
+for _stray in ONNX_PATH.parent.glob(ONNX_PATH.name + "*"):
+    if _stray != ONNX_PATH and _stray.suffix != ".onnx":
+        _stray.unlink()
+        print(f"removed stray external-data file: {_stray.name}")
+onnx.checker.check_model(str(ONNX_PATH))
+print(f"Self-contained ONNX: {ONNX_PATH} ({ONNX_PATH.stat().st_size/1e6:.1f} MB)")
+"""))
+
+cells.append(md("## 9. Parity check: ONNX vs PyTorch (against the consolidated file)"))
 cells.append(code("""\
 import onnxruntime as ort
 import numpy as np
@@ -480,8 +502,11 @@ upload_folder(
     path_in_repo=".",
     repo_id=REPO,
     repo_type="model",
-    allow_patterns=["*.onnx", "*.txt", "*.json"],
-    commit_message="SyncVSR Vox+LRS2+LRS3 -> ONNX (encoder + CTC head)",
+    # External-data globs included as belt-and-suspenders in case a future
+    # (larger) model legitimately externalizes weights — the consolidation
+    # step in section 8b keeps the current model single-file.
+    allow_patterns=["*.onnx", "*.onnx.data", "*.onnx_data", "*.txt", "*.json"],
+    commit_message="SyncVSR Vox+LRS2+LRS3 -> ONNX (encoder + CTC head, self-contained)",
 )
 print(f"Uploaded -> https://huggingface.co/{REPO}")
 """))

--- a/tools/export_syncvsr_to_onnx.ipynb
+++ b/tools/export_syncvsr_to_onnx.ipynb
@@ -440,7 +440,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 9. Parity check: ONNX vs PyTorch"
+    "## 8b. Consolidate external weights into a single self-contained file\n",
+    "\n",
+    "`torch.onnx.export` can spill tensors to a sibling `<model>.onnx.data`\n",
+    "file. If that file is dropped at upload time (the `allow_patterns` below\n",
+    "only matched `*.onnx`), the model on HF becomes an unusable ~2 MB proto\n",
+    "with dangling external-data references \u2014 the bug that broke the FP32\n",
+    "upload (see `docs/EVAL_RESULTS_2026-05-13.md`). Re-save as a single file\n",
+    "so the artifact is self-contained (~370 MB < the 2 GB protobuf limit)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import onnx\n",
+    "\n",
+    "_m = onnx.load(str(ONNX_PATH), load_external_data=True)\n",
+    "onnx.save_model(_m, str(ONNX_PATH), save_as_external_data=False)\n",
+    "for _stray in ONNX_PATH.parent.glob(ONNX_PATH.name + \"*\"):\n",
+    "    if _stray != ONNX_PATH and _stray.suffix != \".onnx\":\n",
+    "        _stray.unlink()\n",
+    "        print(f\"removed stray external-data file: {_stray.name}\")\n",
+    "onnx.checker.check_model(str(ONNX_PATH))\n",
+    "print(f\"Self-contained ONNX: {ONNX_PATH} ({ONNX_PATH.stat().st_size/1e6:.1f} MB)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 9. Parity check: ONNX vs PyTorch (against the consolidated file)"
    ]
   },
   {
@@ -558,8 +590,11 @@
     "    path_in_repo=\".\",\n",
     "    repo_id=REPO,\n",
     "    repo_type=\"model\",\n",
-    "    allow_patterns=[\"*.onnx\", \"*.txt\", \"*.json\"],\n",
-    "    commit_message=\"SyncVSR Vox+LRS2+LRS3 -> ONNX (encoder + CTC head)\",\n",
+    "    # External-data globs included as belt-and-suspenders in case a future\n",
+    "    # (larger) model legitimately externalizes weights \u2014 the consolidation\n",
+    "    # step in section 8b keeps the current model single-file.\n",
+    "    allow_patterns=[\"*.onnx\", \"*.onnx.data\", \"*.onnx_data\", \"*.txt\", \"*.json\"],\n",
+    "    commit_message=\"SyncVSR Vox+LRS2+LRS3 -> ONNX (encoder + CTC head, self-contained)\",\n",
     ")\n",
     "print(f\"Uploaded -> https://huggingface.co/{REPO}\")\n"
    ]

--- a/tools/syncvsr_export_stage2.py
+++ b/tools/syncvsr_export_stage2.py
@@ -104,7 +104,29 @@ torch.onnx.export(
 )
 print(f"[stage2] Exported: {ONNX_PATH} ({ONNX_PATH.stat().st_size/1e6:.1f} MB)")
 
-# Parity check ORT vs PyTorch.
+# Consolidate any external weights into a single self-contained .onnx.
+# torch.onnx.export can spill tensors to a sibling `<model>.onnx.data`
+# (or `<model>.onnx_data`) file; if that file is then dropped at upload
+# time, the model on HF is an unusable ~2 MB proto with dangling
+# external-data references — exactly the bug that broke the FP32 upload
+# (see docs/EVAL_RESULTS_2026-05-13.md, Followups #4). Re-save as a
+# single file so the artifact is self-contained. ~370 MB is well under
+# the 2 GB protobuf limit, so a single file is valid.
+import onnx
+
+print("[stage2] Consolidating external weights into a self-contained ONNX ...")
+_m = onnx.load(str(ONNX_PATH), load_external_data=True)
+onnx.save_model(_m, str(ONNX_PATH), save_as_external_data=False)
+for _stray in ONNX_PATH.parent.glob(ONNX_PATH.name + "*"):
+    if _stray != ONNX_PATH and _stray.suffix != ".onnx":
+        _stray.unlink()
+        print(f"[stage2] removed stray external-data file: {_stray.name}")
+onnx.checker.check_model(str(ONNX_PATH))
+print(f"[stage2] Self-contained ONNX: {ONNX_PATH} ({ONNX_PATH.stat().st_size/1e6:.1f} MB)")
+
+# Parity check ORT vs PyTorch — run AGAINST the consolidated file so we
+# validate the exact artifact that gets uploaded, not a pre-consolidation
+# graph.
 import onnxruntime as ort
 import numpy as np
 
@@ -168,8 +190,11 @@ upload_folder(
     path_in_repo=".",
     repo_id=REPO,
     repo_type="model",
-    allow_patterns=["*.onnx", "*.txt", "*.json"],
-    commit_message="SyncVSR Vox+LRS2+LRS3 -> ONNX (encoder + CTC head)",
+    # Include external-data globs as belt-and-suspenders in case a future
+    # (larger) model legitimately externalizes weights — though the
+    # consolidation step above keeps the current model single-file.
+    allow_patterns=["*.onnx", "*.onnx.data", "*.onnx_data", "*.txt", "*.json"],
+    commit_message="SyncVSR Vox+LRS2+LRS3 -> ONNX (encoder + CTC head, self-contained)",
 )
 print(f"[stage2] Uploaded -> https://huggingface.co/{REPO}")
 print("[stage2] DONE")


### PR DESCRIPTION
@
Production-readiness audit, **Phase 1 / A4**.

## Problem
The FP32 `syncvsr_lrs3_visual_ctc.onnx` on `HereLiesAz/liperty-syncvsr-onnx` is an unusable ~2 MB proto: `torch.onnx.export` spilled weights to a sibling `.onnx.data` file, and the upload `allow_patterns=["*.onnx", ...]` did not match `*.onnx.data`, so the weights were dropped — leaving dangling external-data references. Only the FP16 build loads. (`docs/EVAL_RESULTS_2026-05-13.md`, Followups #4.)

## Fix
- After export, **consolidate** into a single self-contained file: `onnx.load(load_external_data=True)` -> `onnx.save_model(save_as_external_data=False)` -> strip stray `.onnx.data` siblings -> `onnx.checker.check_model`. ~370 MB < 2 GB protobuf limit, so single-file is valid.
- Parity check now runs against the **consolidated** artifact.
- Upload `allow_patterns` broadened to include `*.onnx.data` / `*.onnx_data` as insurance.

Applied to `tools/syncvsr_export_stage2.py` (standalone) and `tools/_build_export_syncvsr_notebook.py` (generator); regenerated `tools/export_syncvsr_to_onnx.ipynb`.

## Caveat
Tooling-only. A Kaggle re-run of the export is still required to actually replace the broken FP32 artifact on HF — that cannot be done from CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@

## Summary by Sourcery

Ensure SyncVSR FP32 ONNX exports are uploaded as self-contained, production-ready artifacts.

Enhancements:
- Add a consolidation step to re-save exported ONNX models as single self-contained files and remove stray external data files.
- Update parity checking in the export notebook to validate against the consolidated ONNX artifact.
- Broaden Hugging Face upload allow_patterns and commit messages so external ONNX data files are handled safely while keeping the current model single-file.

Documentation:
- Extend the export notebook documentation to describe ONNX external-data handling and the new consolidation step.