### PR TITLE
A4 follow-ups: opset-17 export (dynamo=False) + EVAL Followup #4 resolved

### DIFF
--- a/docs/EVAL_RESULTS_2026-05-13.md
+++ b/docs/EVAL_RESULTS_2026-05-13.md
@@ -125,13 +125,21 @@ In order of immediate utility:
    speaker mouthing real natural-English phrases and see what comes
    out. The eval notebook's job (give a number) won't be doable
    until 1 lands; on-device qualitative is the substitute.
-4. **Re-export the FP32 SyncVSR CTC ONNX as a self-contained file.**
-   The current `syncvsr_lrs3_visual_ctc.onnx` on HF is 2 MB of proto
-   with external-data references but the `.onnx.data` file got
-   filtered out by `tools/syncvsr_export_stage2.py`'s
-   `upload_folder(allow_patterns=["*.onnx", "*.txt", "*.json"])`.
-   FP16 works around it but the FP32 should be valid for the same
-   reason — useful for accuracy-vs-FP16 comparison if ever needed.
-   Fix: rerun stage 2 with `save_as_external_data=False` on the
-   `torch.onnx.export` call, or do an `onnx.save_model` merge of
-   the existing .onnx + .onnx.data files.
+4. ~~**Re-export the FP32 SyncVSR CTC ONNX as a self-contained file.**~~
+   **RESOLVED 2026-05-31.** The FP32 `syncvsr_lrs3_visual_ctc.onnx` on HF
+   was 2 MB of proto with external-data references because the `.onnx.data`
+   file got filtered out by the `upload_folder(allow_patterns=["*.onnx",
+   "*.txt", "*.json"])` call. Fixed by adding a consolidation step to both
+   `tools/syncvsr_export_stage2.py` and the
+   `tools/_build_export_syncvsr_notebook.py` generator: after export,
+   `onnx.load(load_external_data=True)` → `onnx.save_model(
+   save_as_external_data=False)` → strip stray external-data files →
+   `onnx.checker`. Re-ran the export on Kaggle and uploaded: HF now serves
+   a **776 MB self-contained** file (commit `89ae9ff`), parity vs PyTorch
+   max abs diff 2.6e-5, `onnx.checker` clean.
+   - Known caveat: the notebook export landed at the dynamo exporter's
+     native opset (the opset-17 downgrade hit a non-fatal version_converter
+     failure). The generator's `torch.onnx.export` now passes `dynamo=False`
+     to force the legacy JIT-trace path at opset 17 (matching the FP16
+     build); the artifact already on HF predates that change but loads/runs
+     correctly in ORT regardless.

--- a/tools/_build_export_syncvsr_notebook.py
+++ b/tools/_build_export_syncvsr_notebook.py
@@ -398,6 +398,12 @@ torch.onnx.export(
     },
     opset_version=17,
     do_constant_folding=True,
+    # torch 2.10 defaults to the dynamo exporter, which leaves the model
+    # at its native opset (the opset_version=17 downgrade hits a non-fatal
+    # onnxscript version_converter failure). Force the legacy JIT-trace
+    # path so the FP32 export lands at opset 17, matching the FP16 build
+    # and tools/syncvsr_export_stage2.py.
+    dynamo=False,
 )
 print(f"Exported: {ONNX_PATH} ({ONNX_PATH.stat().st_size/1e6:.1f} MB)")
 """))

--- a/tools/export_syncvsr_to_onnx.ipynb
+++ b/tools/export_syncvsr_to_onnx.ipynb
@@ -432,6 +432,12 @@
     "    },\n",
     "    opset_version=17,\n",
     "    do_constant_folding=True,\n",
+    "    # torch 2.10 defaults to the dynamo exporter, which leaves the model\n",
+    "    # at its native opset (the opset_version=17 downgrade hits a non-fatal\n",
+    "    # onnxscript version_converter failure). Force the legacy JIT-trace\n",
+    "    # path so the FP32 export lands at opset 17, matching the FP16 build\n",
+    "    # and tools/syncvsr_export_stage2.py.\n",
+    "    dynamo=False,\n",
     ")\n",
     "print(f\"Exported: {ONNX_PATH} ({ONNX_PATH.stat().st_size/1e6:.1f} MB)\")\n"
    ]


### PR DESCRIPTION
@
Follow-ups surfaced while re-exporting the self-contained FP32 SyncVSR CTC ONNX on Kaggle.

- **`tools/_build_export_syncvsr_notebook.py`**: pass `dynamo=False` to `torch.onnx.export`. torch 2.10 defaults to the dynamo exporter, which left the model at its native opset (the `opset_version=17` downgrade hit a non-fatal `onnxscript` version_converter failure during the live run). The legacy JIT-trace path lands at opset 17, matching the FP16 build and `tools/syncvsr_export_stage2.py` (already `dynamo=False`). Regenerated `tools/export_syncvsr_to_onnx.ipynb`.
- **`docs/EVAL_RESULTS_2026-05-13.md`**: mark Followup #4 **RESOLVED**. HF now serves a 776 MB self-contained `syncvsr_lrs3_visual_ctc.onnx` (commit `89ae9ff`), parity vs PyTorch max abs diff 2.6e-5, `onnx.checker` clean.

Tooling-only; no app code touched. The artifact already on HF predates the `dynamo=False` change but loads/runs correctly in ORT (parity-proven).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@

## Summary by Sourcery

Update SyncVSR ONNX export tooling to ensure FP32 models are exported at opset 17 and document the resolution of the FP32 self-contained artifact follow-up.

Enhancements:
- Force the SyncVSR FP32 ONNX export notebook generator to use the legacy JIT-trace exporter with opset 17 by disabling dynamo.
- Regenerate the SyncVSR ONNX export notebook to reflect the updated export configuration.

Documentation:
- Mark the FP32 self-contained SyncVSR CTC ONNX follow-up as resolved and document the new consolidated, self-contained artifact and its validation details.