### PR TITLE
ci: raise unit-test cap to 45m (suite is slow, not hung)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,14 +141,14 @@ jobs:
       # small text assets pulled by setup_libs.sh above. A test failure fails
       # the job before assembleRelease runs.
       - name: Run unit tests
-        # TEMPORARY: bounded + non-blocking. This runs main's full Robolectric
-        # suite in CI for the first time (the KenLM gate previously blocked it),
-        # and a test hangs (>30 min). Cap the step so it can't stall the
-        # pipeline, and don't fail the build on it yet so a fresh APK still
-        # ships. `started` test logging (app/build.gradle.kts) makes the
-        # captured log show the last test to start = the hang culprit.
-        # RESTORE the hard gate (remove continue-on-error) once it's fixed.
-        timeout-minutes: 12
+        # The full Robolectric suite is just SLOW, not hung: each @Config(sdk=34)
+        # class spins up a fresh Android sandbox + LipertyApplication.onCreate,
+        # and cold (no Gradle/Robolectric cache) the whole suite runs ~30 min.
+        # Generous cap so a genuine hang would still be caught, but the slow
+        # suite can finish. Kept non-blocking for ONE confirming run to observe
+        # a clean completion + real duration; the hard gate (remove
+        # continue-on-error) is restored next once green.
+        timeout-minutes: 45
         continue-on-error: true
         run: ./gradlew testDebugUnitTest --stacktrace
 


### PR DESCRIPTION
Corrects an over-aggressive 12-min cap. The Robolectric suite spins up a fresh sandbox + LipertyApplication.onCreate per @Config(sdk=34) class and runs ~30 min cold, but it was progressing (capped mid-run), not deadlocked. Raise the cap so it completes; kept non-blocking for one confirming run to capture a clean completion + real duration, then the hard gate is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Raise the GitHub Actions unit-test step timeout from 12 to 45 minutes to accommodate the full Robolectric suite run time while still guarding against genuine hangs.