### PR TITLE
fix: bug sweep — OnnxModelEngine VALLR default + bounded download redirects

### DIFF
--- a/app/src/main/java/com/hereliesaz/liperty/ml/OnnxModelEngine.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/ml/OnnxModelEngine.kt
@@ -10,21 +10,23 @@ import java.nio.ByteBuffer
 import java.nio.FloatBuffer
 
 /**
- * ModelEngine backed by ONNX Runtime. Built for the VALLR VideoMAE → Wav2Vec2-CTC
- * checkpoint exported from PyTorch, which expects NCTHW input
- * (1, 3, 16, 224, 224) and produces (1, 8, 40) phoneme logits.
+ * ModelEngine backed by ONNX Runtime — the production VSR backend. Serves the
+ * SyncVSR visual encoder + CTC head (NTCHW `(1, T, 1, 88, 88)` → `(1, T_out,
+ * 5049)` log-softmax) and, as an alternate, the Auto-AVSR Conformer + CTC
+ * (NCTHW `(1, 1, T, 88, 88)` → `(1, T_out, 5050)`). The concrete model and
+ * layout are passed in by the caller (see `MainActivity`).
  *
- * Loads the .onnx file from app assets — bundled at build time.
+ * Loads the .onnx from filesDir (downloaded by `ModelDownloadManager` on first
+ * launch) or from bundled assets (dev builds with setup_libs.sh).
  */
 class OnnxModelEngine(
     private val context: Context,
-    private val modelName: String = "vallr_model.onnx",
+    private val modelName: String,
     /** Layout the loaded model expects for its primary input tensor.
-     *  Auto-AVSR uses NCTHW; SyncVSR uses NTCHW. Callers pass whichever
-     *  matches the bundled ONNX so VSRInference writes pixels in the
-     *  right axis order. Default NCTHW keeps the historical behaviour
-     *  (VALLR/Auto-AVSR exports). */
-    private val expectedInputLayout: InputLayout = InputLayout.NCTHW,
+     *  SyncVSR uses NTCHW; Auto-AVSR uses NCTHW. Callers pass whichever
+     *  matches the loaded ONNX so VSRInference writes pixels in the
+     *  right axis order. */
+    private val expectedInputLayout: InputLayout = InputLayout.NTCHW,
 ) : ModelEngine {
 
     private var env: OrtEnvironment? = null

--- a/app/src/main/java/com/hereliesaz/liperty/setup/ModelDownloadManager.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/setup/ModelDownloadManager.kt
@@ -52,6 +52,10 @@ class ModelDownloadManager(private val context: Context) {
 
         /** Buffer size for streaming downloads. */
         private const val BUFFER_SIZE = 64 * 1024 // 64 KB
+
+        /** Max manual (cross-protocol) redirect hops before giving up, so a
+         *  misconfigured redirect loop can't recurse into a StackOverflowError. */
+        private const val MAX_REDIRECTS = 5
     }
 
     // ── Model manifest ────────────────────────────────────────────────
@@ -449,7 +453,7 @@ class ModelDownloadManager(private val context: Context) {
     }
 
     private suspend fun downloadFile(
-        urlStr: String, dest: File, modelKey: String
+        urlStr: String, dest: File, modelKey: String, redirectsLeft: Int = MAX_REDIRECTS
     ): Unit = withContext(Dispatchers.IO) {
         var conn: HttpURLConnection? = null
         try {
@@ -463,12 +467,17 @@ class ModelDownloadManager(private val context: Context) {
             if (responseCode != HttpURLConnection.HTTP_OK) {
                 // HuggingFace returns 302 → CDN. HttpURLConnection follows
                 // redirects automatically for same-protocol. For cross-protocol
-                // (http→https) we handle manually.
+                // (http→https) we handle manually — bounded by [redirectsLeft]
+                // so a misconfigured redirect loop can't recurse to a
+                // StackOverflowError.
                 if (responseCode in 300..399) {
                     val redirect = conn.getHeaderField("Location")
                     conn.disconnect()
                     if (redirect != null) {
-                        downloadFile(redirect, dest, modelKey)
+                        if (redirectsLeft <= 0) {
+                            throw RuntimeException("Too many redirects fetching $modelKey (loop?)")
+                        }
+                        downloadFile(redirect, dest, modelKey, redirectsLeft - 1)
                         return@withContext
                     }
                 }


### PR DESCRIPTION
A thorough sweep of the high-risk surface (ML decode path, DSP, ONNX/resource lifecycle, the downloader). Two concrete bugs fixed; the rest of the reviewed core is solid.

## Fixes
1. **`OnnxModelEngine`** — the constructor defaulted `modelName` to the now-deleted `vallr_model.onnx`, and the class doc described a VALLR VideoMAE checkpoint with wrong shapes (`NCTHW (1,3,16,224,224)` / 5050 vocab). Removed the dead default (only `MainActivity` constructs it, passing `modelName` explicitly), corrected the doc to the real SyncVSR/Auto-AVSR contract, and set the default layout to SyncVSR's **NTCHW**.
2. **`ModelDownloadManager.downloadFile()`** — recursed on every cross-protocol HTTP redirect with **no depth limit**; a misconfigured redirect loop would recurse into a `StackOverflowError`. Bounded by `MAX_REDIRECTS = 5`.

## Reviewed and found solid (no changes)
- **Decoders:** `Seq2SeqGreedyDecoder` (BOS/EOS/argmax), `SubwordCtcBeamDecoder` (CTC prefix-merge, `logSumExp` NEG_INF handling) — verified the probabilities-not-logprobs contract holds (`VSRInference` applies `softmax(log_softmax)`, which exactly recovers probabilities).
- **`FrameBuffer`** — sliding-window copy/recycle ownership is correct (no double-free; originals go to the caller, copies stay in the buffer).
- **`VSRInference`** — buffer sizing uses checked Long capacities; output buffer is over-allocated to an upper bound and CTC downsampling keeps `T_out ≤ T_in`, so `copyTensorTo` can't overflow.
- **`VibraPhoneDSP`** — FFT/LPC(Levinson-Durbin)/mel bounds and div-by-zero guards check out.
- **`HandGestureHelper`** — `.first()/.last()` are guarded by the `HISTORY_SIZE` check.
- **Resource lifecycle** — `PocketTTSEngine`/`OrtTrainer` ONNX tensors are `.use`/`finally`-closed; `CameraManager` executor + AvHubert sessions have release paths.

## Noted, not fixed (out of scope / low-confidence)
- `VibraPhoneDSP.trambaBandwidthExpansion` conjugate-mirror can overwrite low-frequency bins when `i > N/2` — but TRAMBA is an unshipped 'Future' feature; fixing DSP without tests is risky.

## Coverage honesty
This deep-read the core inference + DSP + downloader + ONNX-resource surface (~10 files) plus crash-pattern greps (`!!`, `GlobalScope`, `first/last`, unclosed tensors/sessions/executors) across all 95 source files. It did **not** line-by-line audit the Compose UI, `voicebox.cloning` internals, or the personalization store — those are candidates for a follow-up pass if you want deeper coverage there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)