### PR TITLE
fix: DSP TRAMBA low-freq corruption + delete-all compliance + WAV hea…

### DIFF
--- a/app/src/main/java/com/hereliesaz/liperty/dsp/VibraPhoneDSP.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/dsp/VibraPhoneDSP.kt
@@ -284,27 +284,41 @@ class VibraPhoneDSP {
         val complexSpectrum = fft(inputSignal)
         val excitedSpectrum = fft(excitedSignal)
 
-        val n = complexSpectrum.size / 2
-        
-        // 2. Spectral Shaping: Reconstruct components above 3kHz
-        val cutoffIdx = (3000 * FRAME_SIZE / SAMPLE_RATE).toInt()
+        val n = complexSpectrum.size / 2   // FFT length N (== inputSignal.size)
+        val nyquist = n / 2
 
-        for (i in cutoffIdx until n) {
-            // Mix original with excited harmonics (scaled)
+        // 2. Spectral shaping: reconstruct the POSITIVE-frequency components above
+        //    3 kHz, then enforce conjugate symmetry so the IFFT stays real.
+        //
+        // Only the positive half [cutoffIdx .. nyquist] is modified. The
+        // negative-frequency bins (nyquist+1 .. n-1) are derived as conjugates
+        // here. The previous implementation iterated [cutoffIdx until n] and, for
+        // each i, wrote a "mirror" at n-i — but for i > nyquist that mirror lands
+        // in the LOW-frequency half, clobbering the original sub-cutoff content
+        // that must be preserved. Bin i maps to freq i*SAMPLE_RATE/n, so the
+        // cutoff is relative to N (not the fixed FRAME_SIZE).
+        val cutoffIdx = (3000L * n / SAMPLE_RATE).toInt().coerceIn(1, nyquist)
+
+        for (i in cutoffIdx..nyquist) {
+            // Mix original with excited harmonics (scaled).
             val re = complexSpectrum[2 * i] + excitedSpectrum[2 * i] * 0.4f
-            val im = complexSpectrum[2 * i + 1] + excitedSpectrum[2 * i + 1] * 0.4f
-            
+            var im = complexSpectrum[2 * i + 1] + excitedSpectrum[2 * i + 1] * 0.4f
+            // The Nyquist bin (and DC) must be real for a real-valued signal.
+            if (i == nyquist) im = 0f
+
             complexSpectrum[2 * i] = re
             complexSpectrum[2 * i + 1] = im
-            
-            // Mirror for conjugate symmetry (negative frequencies)
+
+            // Mirror to the negative-frequency bin as the complex conjugate.
+            // mirrorIdx is in (nyquist .. n-1) for i in [1 .. nyquist-1], so it
+            // never overwrites a positive/low-frequency bin.
             val mirrorIdx = n - i
-            if (mirrorIdx > 0 && mirrorIdx < n) {
+            if (mirrorIdx in (nyquist + 1) until n) {
                 complexSpectrum[2 * mirrorIdx] = re
                 complexSpectrum[2 * mirrorIdx + 1] = -im
             }
         }
-        
+
         return ifft(complexSpectrum)
     }
 
@@ -322,8 +336,11 @@ class VibraPhoneDSP {
     /**
      * Performs a forward FFT on the input signal.
      * @return Interleaved float array [Re, Im, Re, Im...] of size 2*input.size
+     *
+     * internal (not private) so the TRAMBA below-cutoff-preservation regression
+     * test can inspect the spectrum directly.
      */
-    private fun fft(input: FloatArray): FloatArray {
+    internal fun fft(input: FloatArray): FloatArray {
         val n = input.size
         // Ensure n is power of 2
         if (n and (n - 1) != 0) {

--- a/app/src/main/java/com/hereliesaz/liperty/personalization/PairedTrainingStore.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/personalization/PairedTrainingStore.kt
@@ -113,8 +113,18 @@ class PairedTrainingStore(private val rootDir: File) {
         metaFile(id).delete()
     }
 
-    fun deleteAll() {
-        rootDir.listFiles().orEmpty().forEach { it.delete() }
+    /**
+     * The Settings "delete all biometric data" path (GDPR/BIPA right-to-erasure).
+     * Recursively removes the entire store directory — including any stray
+     * subdirectory or partially-written record — then recreates the empty root,
+     * so nothing biometric can be left behind. Returns true only if the tree was
+     * fully removed; a false result means some file could not be deleted (e.g.
+     * locked) and the caller should surface a failure rather than report success.
+     */
+    fun deleteAll(): Boolean {
+        val removed = rootDir.deleteRecursively()
+        rootDir.mkdirs()
+        return removed
     }
 
     fun totalBytes(): Long =

--- a/app/src/main/java/com/hereliesaz/liperty/voicebox/cloning/AudioPreprocessor.kt
+++ b/app/src/main/java/com/hereliesaz/liperty/voicebox/cloning/AudioPreprocessor.kt
@@ -353,6 +353,14 @@ class AudioPreprocessor(private val context: Context) {
         buf.position(34)
         val bitsPerSample = buf.short.toInt()
 
+        // Guard against malformed/untrusted WAV headers — voice-import accepts
+        // user-supplied files. channels==0 or bitsPerSample<8 would divide by
+        // zero below (numSamples / channels, chunkSize / (bitsPerSample/8)).
+        if (channels < 1 || bitsPerSample < 8) {
+            Log.w(TAG, "Invalid WAV header (channels=$channels bits=$bitsPerSample); skipping")
+            return floatArrayOf()
+        }
+
         // Find data chunk
         buf.position(36)
         while (buf.remaining() >= 8) {

--- a/app/src/test/java/com/hereliesaz/liperty/dsp/VibraPhoneDSPTest.kt
+++ b/app/src/test/java/com/hereliesaz/liperty/dsp/VibraPhoneDSPTest.kt
@@ -1,0 +1,71 @@
+package com.hereliesaz.liperty.dsp
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import kotlin.math.cos
+import kotlin.math.hypot
+
+/**
+ * Regression tests for [VibraPhoneDSP.trambaBandwidthExpansion].
+ *
+ * AndroidJUnit4 + sdk=34 because the class's companion `init` calls
+ * `System.loadLibrary` (caught) and `android.util.Log` — both need Robolectric.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class VibraPhoneDSPTest {
+
+    private val dsp = VibraPhoneDSP()
+
+    /**
+     * TRAMBA must only reconstruct frequencies at/above the 3 kHz cutoff; bins
+     * strictly below the cutoff must pass through untouched. The previous
+     * implementation iterated the full upper spectrum and, for negative-frequency
+     * bins (i > N/2), wrote a "conjugate mirror" at N-i that landed in the LOW
+     * half — clobbering the sub-cutoff content (including the input tone). This
+     * test fails on that bug and passes on the fix.
+     */
+    @Test
+    fun trambaPreservesBelowCutoffFrequencies() {
+        val n = 512
+        val sr = VibraPhoneDSP.SAMPLE_RATE          // 16000
+        val cutoffIdx = (3000L * n / sr).toInt()    // 96 — bin of the 3 kHz cutoff
+
+        // Pure cosine at bin 30 (~937 Hz), comfortably below the cutoff.
+        val toneBin = 30
+        assertTrue("tone must sit below the cutoff", toneBin < cutoffIdx)
+        val input = FloatArray(n) { t -> cos(2.0 * Math.PI * toneBin * t / n).toFloat() }
+
+        val inSpec = dsp.fft(input)
+        val out = dsp.trambaBandwidthExpansion(input)
+        assertEquals("output length preserved", n, out.size)
+        val outSpec = dsp.fft(out)
+
+        // Reference magnitude (the tone) used to scale tolerances.
+        val toneMag = hypot(inSpec[2 * toneBin].toDouble(), inSpec[2 * toneBin + 1].toDouble())
+        assertTrue("sanity: tone has energy", toneMag > 1.0)
+
+        // Every positive-frequency bin strictly below the cutoff must be preserved.
+        for (i in 1 until cutoffIdx) {
+            val inMag = hypot(inSpec[2 * i].toDouble(), inSpec[2 * i + 1].toDouble())
+            val outMag = hypot(outSpec[2 * i].toDouble(), outSpec[2 * i + 1].toDouble())
+            assertEquals("below-cutoff bin $i must be preserved", inMag, outMag, toneMag * 0.02)
+        }
+    }
+
+    /** Output stays finite and same-length for a multi-tone input. */
+    @Test
+    fun trambaOutputIsFiniteAndSameLength() {
+        val n = 256
+        val input = FloatArray(n) { t ->
+            (cos(2.0 * Math.PI * 50 * t / n) + 0.3 * cos(2.0 * Math.PI * 100 * t / n)).toFloat()
+        }
+        val out = dsp.trambaBandwidthExpansion(input)
+        assertEquals(n, out.size)
+        for (v in out) assertTrue("sample must be finite", v.isFinite())
+    }
+}


### PR DESCRIPTION
…der guard

Follow-up to the bug sweep, handling the DSP concern and auditing the UI / voicebox.cloning / personalization-store areas.

VibraPhoneDSP.trambaBandwidthExpansion: the conjugate-symmetry mirror wrote X[N-i] for i across the FULL upper spectrum; for i > N/2 that mirror lands in the LOW-frequency half and clobbered the sub-cutoff content that must be preserved. Now iterates only the positive half [cutoffIdx..nyquist] and mirrors to the negative half, forces a real Nyquist bin, and scales the 3 kHz cutoff to the actual FFT length N (not FRAME_SIZE). Added VibraPhoneDSPTest asserting below-cutoff bins are preserved (fails on the old bug); fft() made internal as the test seam.

PairedTrainingStore.deleteAll() (GDPR/BIPA 'delete all biometric data'): replaced a non-recursive listFiles().forEach{delete()} that silently ignored failures and skipped subdirectories with rootDir.deleteRecursively()+mkdirs(), returning whether the tree was fully removed so a failure can't be reported as success.

AudioPreprocessor.loadWav(): voice-import accepts untrusted user .wav files; a malformed header with channels==0 or bitsPerSample<8 divided by zero (numSamples/channels, chunkSize/(bitsPerSample/8)). Guarded.

Audited and found solid: TranscriptionManager (synchronized; correct dedupe/cycle), VAD + linear resample math, VoiceProfileBuilder weights (totalWeight coerced). Noted (not changed): getCleanedSentence runs the optional LLM transform under the monitor — opt-in/unbundled, behavior-preserving fix deferred.