### PR TITLE
fix(proguard): keep ai.onnxruntime — release builds crashed on model init

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -5,7 +5,15 @@
 -keep class com.google.ai.edge.litert.** { *; }
 -keep class com.google.ai.edge.** { *; }
 
-# Keep ONNX Runtime
+# Keep ONNX Runtime.
+# CRITICAL: the Java classes are in package `ai.onnxruntime` — `com.microsoft.onnxruntime`
+# is only the Maven group and matches NO classes. Many ai.onnxruntime members (e.g.
+# NodeInfo's (String, ValueInfo) constructor) are invoked ONLY from native JNI
+# (libonnxruntime4j_jni.so), which R8's static analysis can't see, so without this
+# keep R8 strips them and the native lib crashes with NoSuchMethodError on the first
+# OrtSession.getInputInfo() call (force-close on model init in minified release builds).
+-keep class ai.onnxruntime.** { *; }
+-keepclassmembers class ai.onnxruntime.** { *; }
 -keep class com.microsoft.onnxruntime.** { *; }
 
 # Keep OpenCV classes
@@ -15,6 +23,7 @@
 -dontwarn com.google.mediapipe.**
 -dontwarn com.google.ai.edge.**
 -dontwarn org.tensorflow.lite.**
+-dontwarn ai.onnxruntime.**
 -dontwarn com.microsoft.onnxruntime.**
 -dontwarn org.opencv.**
 


### PR DESCRIPTION
## Crash (Pixel 5, release APK)
```
F: java.lang.NoSuchMethodError: no non-static method
   "Lai/onnxruntime/NodeInfo;.<init>(Ljava/lang/String;Lai/onnxruntime/ValueInfo;)V"
     at ai.onnxruntime.OrtSession.getInputInfo(...)
     at OnnxModelEngine.initialize() -> VSRInference.initialize()
```

## Root cause
The ProGuard keep rule was `-keep class com.microsoft.onnxruntime.** { *; }` — that's the **Maven group**, but ORT's Java classes are in package **`ai.onnxruntime`**. The rule matched nothing, so R8 (release `isMinifyEnabled=true`) stripped `ai.onnxruntime` members that are only referenced from native JNI (`libonnxruntime4j_jni.so`). The native lib then called the now-missing `NodeInfo(String, ValueInfo)` constructor → `NoSuchMethodError` → force-close on the **first model init**. Every minified release APK was affected (debug builds aren't minified, so they were fine).

## Fix
Keep `ai.onnxruntime.**` (the actual package), plus matching `-keepclassmembers` and `-dontwarn`. One ORT artifact (`onnxruntime-training-android:1.19.2`); no version skew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update ProGuard configuration to correctly preserve ONNX Runtime Java classes used via JNI to prevent release-build crashes during model initialization.

Bug Fixes:
- Fix release-build crashes caused by R8 stripping ai.onnxruntime classes and constructors invoked only from native JNI code.

Build:
- Adjust ProGuard keep and dontwarn rules to target the correct ai.onnxruntime package instead of only the com.microsoft.onnxruntime Maven group.